### PR TITLE
fix: cuando se deriva una determinacion se muestra la leyenda  "Derivado: 'Efector destino'"

### DIFF
--- a/WebLab/Derivaciones/InformeLote.aspx.cs
+++ b/WebLab/Derivaciones/InformeLote.aspx.cs
@@ -479,16 +479,15 @@ namespace WebLab.Derivaciones
 
                             #region cambio_codificacion_a_derivacion
                             //Cambia el resultado de LAB_DetalleProtocolo
-                            //DetalleProtocolo oDet = new DetalleProtocolo();
-                            //oDet = (DetalleProtocolo) oDet.Get(typeof(DetalleProtocolo), oDeriva.IdDetalleProtocolo.IdDetalleProtocolo);
-                            //oDet.ResultadoCar = resultadoDerivacion;
-                            //oDet.ConResultado = true;
-                            //oDet.IdUsuarioResultado = idUsuario;
-                            ////oDet.FechaResultado = DateTime.Now;
-                            //oDet.FechaResultado = Convert.ToDateTime(fecha_hora);
-                            //oDet.Save();
-                            ////Inserta auditoria del detalle del protocolo
-                            //oDet.GrabarAuditoriaDetalleProtocolo("Graba", idUsuario);
+                            DetalleProtocolo oDet = new DetalleProtocolo();
+                            oDet = (DetalleProtocolo)oDet.Get(typeof(DetalleProtocolo), oDeriva.IdDetalleProtocolo.IdDetalleProtocolo);
+                            oDet.ResultadoCar = resultadoDerivacion;
+                            oDet.ConResultado = true;
+                            oDet.IdUsuarioResultado = idUsuario;
+                            oDet.FechaResultado = Convert.ToDateTime(fecha_hora);
+                            oDet.Save();
+                            //Inserta auditoria del detalle del protocolo
+                            oDet.GrabarAuditoriaDetalleProtocolo("Graba", idUsuario);
                             #endregion
                         }
                     }


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
<!-- URL de la User Story, referencia al issue (#1111) o breve descripcion del requerimiento -->

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
Se realiza una prueba completa de las derivaciones y se revisa las impresiones de las determinaciones en cada uno de sus estados, se compara TEST con LOCAL.

|ACCION | TEST | LOCAL | Validacion|
-- | -- | -- | --
Antes de derivar | No hay valores en las impresiones | (Estado Pendiente de Derivacion) En ambas impresiones sale la leyenda que la muestra está “Pendiente de derivar” | Ok 
Después de derivar | (Estado Enviado) En ambas impresiones sale la leyenda que la muestra fue “Derivado a ‘Efector Destino’” | En ambas impresiones sale la leyenda que la muestra está “Pendiente de derivar” | Corregir a como está en producción. Que se muestre el efector destino una vez que se deriva. Debe mostrar  “Derivado a ‘Efector Destino’”   , no “pendiente de derivar”.
Recepción de muestra | En la impresión de carga no hay valores, en la impresión (Resultados Impresión) se mantiene la leyenda de “Derivado a ‘Efector Destino’” | En la impresión de carga no hay valores, en la impresión (Resultados Impresión) se mantiene la leyenda de “Pendiente de derivar” | No se debe mostrar resultados por el momento. Se debe mantener la leyenda “Derivado a ‘Efector Destino’”
Auditoria de protocolo | Se graba la información que fue derivado “Derivado a ‘Efector Destino’” y que fue recibido indicando el número de protocolo nuevo generado | Se graba la información que esta “Pendiente para derivar” y que luego fue recibido indicando el número de protocolo nuevo generado | Se debe mantener como está en test. Corregir.


### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [X] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->
### Jira
Fixes LAB-125
```markdown
Fixes LAB-125
```
<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->