### PR TITLE
(LAB-236) Bug de tildado sin muestra automatico

### DIFF
--- a/Business/Data/Laboratorio/Configuracion.cs
+++ b/Business/Data/Laboratorio/Configuracion.cs
@@ -152,6 +152,7 @@ namespace Business.Data.Laboratorio
         private string m_urlResultadosQR;
 
         private bool m_verificaIngresoAnterior;
+        private bool m_habilitaEnfermedadBase;
         private string m_tipoOrdenProtocolo;
 
         #endregion
@@ -304,6 +305,7 @@ namespace Business.Data.Laboratorio
             m_verificaIngresoAnterior = false;
             m_habilitaNoPublicacion = false;
             m_tipoOrdenProtocolo = String.Empty;
+            m_habilitaEnfermedadBase = false;
 
         }
 
@@ -453,8 +455,8 @@ int valordefectofechatomamuestra,
         string tokenMPI  ,
         string  urlResultadosQR ,
         bool verificaIngresoAnterior,
-        string  tipoOrdenProtocolo
-
+        string  tipoOrdenProtocolo,
+            bool habilitaEnfermedadBase
             )
             : this()
 		{
@@ -592,6 +594,7 @@ int valordefectofechatomamuestra,
 
             m_verificaIngresoAnterior = verificaIngresoAnterior;
             m_tipoOrdenProtocolo = tipoOrdenProtocolo;
+            m_habilitaEnfermedadBase = habilitaEnfermedadBase;
         }
 		#endregion // End Required Fields Only Constructor
 
@@ -793,6 +796,17 @@ int valordefectofechatomamuestra,
             {
                 m_isChanged |= (m_habilitaNoPublicacion != value);
                 m_habilitaNoPublicacion = value;
+            }
+
+        }
+
+        public bool HabilitaEnfermedadBase
+        {
+            get { return m_habilitaEnfermedadBase; }
+            set
+            {
+                m_isChanged |= (m_habilitaEnfermedadBase != value);
+                m_habilitaEnfermedadBase = value;
             }
 
         }

--- a/Business/Data/Laboratorio/Configuracion.hbm.xml
+++ b/Business/Data/Laboratorio/Configuracion.hbm.xml
@@ -155,5 +155,6 @@
     <property column="tipoOrdenProtocolo" type="String" name="TipoOrdenProtocolo"   />
 
     <property column="verificaIngresoAnterior" type="Boolean" name="VerificaIngresoAnterior" not-null="true" />
+    <property column="habilitaEnfermedadBase" type="Boolean" name="HabilitaEnfermedadBase" not-null="true" />
   </class>
 </hibernate-mapping>

--- a/Business/Data/Laboratorio/DetalleProtocolo.cs
+++ b/Business/Data/Laboratorio/DetalleProtocolo.cs
@@ -1324,7 +1324,7 @@ namespace Business.Data.Laboratorio
                 return false;
         }
 
-        public string getPlaca()
+        public string getPlaca_old()
         {
             string s_placa = "";
             ICriteria crit = m_session.CreateCriteria(typeof(DetalleProtocoloPlaca));
@@ -1345,6 +1345,26 @@ namespace Business.Data.Laboratorio
                 }
             }
             return s_placa;
+        }
+
+        public string getPlaca()
+        {
+            ICriteria crit = m_session.CreateCriteria(typeof(DetalleProtocoloPlaca));
+            crit.Add(Expression.Eq("IdDetalleProtocolo", this.IdDetalleProtocolo));
+
+            IList lista = crit.List();
+
+            HashSet<int> placas = new HashSet<int>();
+
+            foreach (DetalleProtocoloPlaca oDetalle in lista)
+            {
+                Placa oP = (Placa)m_session.Get(typeof(Placa), oDetalle.IdPlaca);
+
+                if (!oP.Baja)
+                    placas.Add(oDetalle.IdPlaca);
+            }
+
+            return string.Join("-", placas);
         }
 
         public bool esDerivado()

--- a/Business/Data/Laboratorio/Item.cs
+++ b/Business/Data/Laboratorio/Item.cs
@@ -863,7 +863,7 @@ namespace Business.Data.Laboratorio
         public bool VerificaMuestrasAsociadas(int idMuestra)
         {
             bool dev = true;
-            if (this.IdArea.IdTipoServicio.IdTipoServicio == 3) //micro
+            if ((this.IdArea.IdTipoServicio.IdTipoServicio == 3) && (idMuestra>0))//micro: se agrega control que se haya ingresado una muestra
             {
                 ISession m_session = NHibernateHttpModule.CurrentSession;
                 ICriteria crit = m_session.CreateCriteria(typeof(ItemMuestra));

--- a/Business/Data/Laboratorio/ProtocoloDiagnostico.cs
+++ b/Business/Data/Laboratorio/ProtocoloDiagnostico.cs
@@ -19,20 +19,22 @@ namespace Business.Data.Laboratorio
 		private int m_idprotocolodiagnostico; 
 		private Protocolo m_idprotocolo; 
 		private Efector m_idefector; 
-		private int m_iddiagnostico; 		
-		#endregion
+		private int m_iddiagnostico;
+        private string m_tipo;
+        #endregion
 
-		#region Default ( Empty ) Class Constuctor
-		/// <summary>
-		/// default constructor
-		/// </summary>
-		public ProtocoloDiagnostico()
+        #region Default ( Empty ) Class Constuctor
+        /// <summary>
+        /// default constructor
+        /// </summary>
+        public ProtocoloDiagnostico()
 		{
 			m_idprotocolodiagnostico = 0; 
 			m_idprotocolo = new Protocolo(); 
 			m_idefector = new Efector(); 
-			m_iddiagnostico = 0; 
-		}
+			m_iddiagnostico = 0;
+            m_tipo = String.Empty;
+        }
 		#endregion // End of Default ( Empty ) Class Constuctor
 
 		#region Required Fields Only Constructor
@@ -42,13 +44,15 @@ namespace Business.Data.Laboratorio
 		public ProtocoloDiagnostico(
 			Protocolo idprotocolo, 
 			Efector idefector, 
-			int iddiagnostico)
+			int iddiagnostico,
+            string tipo)
 			: this()
 		{
 			m_idprotocolo = idprotocolo;
 			m_idefector = idefector;
 			m_iddiagnostico = iddiagnostico;
-		}
+            m_tipo = tipo;
+        }
 		#endregion // End Required Fields Only Constructor
 
 		#region Public Properties
@@ -108,11 +112,28 @@ namespace Business.Data.Laboratorio
 			}
 
 		}
-			
-		/// <summary>
-		/// Returns whether or not the object has changed it's values.
-		/// </summary>
-		public bool IsChanged
+
+
+        public string Tipo
+        {
+            get { return m_tipo; }
+
+            set
+            {
+                if (value == null)
+                    throw new ArgumentOutOfRangeException("Null value not allowed for m_tipo", value, "null");
+
+                if (value.Length > 10)
+                    throw new ArgumentOutOfRangeException("Invalid value for m_tipo", value, value.ToString());
+
+                m_isChanged |= (m_tipo != value); m_tipo = value;
+            }
+        }
+
+        /// <summary>
+        /// Returns whether or not the object has changed it's values.
+        /// </summary>
+        public bool IsChanged
 		{
 			get { return m_isChanged; }
 		}

--- a/Business/Data/Laboratorio/ProtocoloDiagnostico.hbm.xml
+++ b/Business/Data/Laboratorio/ProtocoloDiagnostico.hbm.xml
@@ -11,6 +11,6 @@
     <!--<property column="idProtocolo" type="Int32" name="IdProtocolo" not-null="true" />
 		<property column="idEfector" type="Int32" name="IdEfector" not-null="true" />-->
 		<property column="idDiagnostico" type="Int32" name="IdDiagnostico" not-null="true" />
-		
+    <property column="tipo" type="String" name="Tipo"   />
 	</class>
 </hibernate-mapping>

--- a/WebLab/AutoAnalizador/ProtocoloBusqueda2.aspx.cs
+++ b/WebLab/AutoAnalizador/ProtocoloBusqueda2.aspx.cs
@@ -156,7 +156,8 @@ namespace WebLab.AutoAnalizador
 
 
             ///Carga de Sectores          
-            string m_ssql = "SELECT idSectorServicio, prefijo + ' - ' + nombre as nombre  FROM LAB_SectorServicio WHERE (baja = 0) order by nombre";
+            string m_ssql = @"SELECT idSectorServicio, prefijo + ' - ' + nombre as nombre  FROM LAB_SectorServicio S with (nolock) WHERE (baja = 0) 
+                          and exists(select 1 from Lab_SectorServicioEfector SE with (nolock)  where SE.idSectorServicio = S.idSectorServicio and se.idefector = " + oUser.IdEfector.IdEfector.ToString()+@")  order by nombre";                
             oUtil.CargarListBox(lstSector, m_ssql, "idSectorServicio", "nombre");
             for (int i = 0; i < lstSector.Items.Count; i++)
             {
@@ -281,33 +282,7 @@ order by tipoMuestra";
                     if (txtProtocoloDesde.Value != "") m_parametro += " And P.numero>=" + int.Parse(txtProtocoloDesde.Value);
                     if (txtProtocoloHasta.Value != "") m_parametro += " AND  P.numero<=" + int.Parse(txtProtocoloHasta.Value);
 
-               /*     switch (oC.TipoNumeracionProtocolo)// busqueda con autonumerico
-                    {
-                        case 0:
-                            {
-                                if (txtProtocoloDesde.Value != "") m_parametro += " And P.numero>=" + int.Parse(txtProtocoloDesde.Value);
-                                if (txtProtocoloHasta.Value != "") m_parametro += " AND  P.numero<=" + int.Parse(txtProtocoloHasta.Value);
-                            }
-                            break;
-                        case 1:
-                            {
-                                if (txtProtocoloDesde.Value != "") m_parametro += " And P.numeroDiario>=" + int.Parse(txtProtocoloDesde.Value);
-                                if (txtProtocoloHasta.Value != "") m_parametro += " AND  P.numeroDiario<=" + int.Parse(txtProtocoloHasta.Value);
-                            }
-                            break;
-                        case 2:
-                            {
-                                if (txtProtocoloDesde.Value != "") m_parametro += " And P.numeroSector>=" + int.Parse(txtProtocoloDesde.Value);
-                                if (txtProtocoloHasta.Value != "") m_parametro += " AND  P.numeroSector<=" + int.Parse(txtProtocoloHasta.Value);
-                            }
-                            break;
-                        case 3:
-                            {
-                                if (txtProtocoloDesde.Value != "") m_parametro += " And P.numeroTipoServicio>=" + int.Parse(txtProtocoloDesde.Value);
-                                if (txtProtocoloHasta.Value != "") m_parametro += " AND  P.numeroTipoServicio<=" + int.Parse(txtProtocoloHasta.Value);
-                            }
-                            break;
-                    }*/
+             
 
 
                     if (ddlEfector.SelectedValue != "0") m_parametro += " AND P.idEfectorSolicitante=" + ddlEfector.SelectedValue;

--- a/WebLab/ControlResultados/ControlPlanilla.aspx.cs
+++ b/WebLab/ControlResultados/ControlPlanilla.aspx.cs
@@ -83,7 +83,8 @@ namespace WebLab.ControlResultados
             oUtil.CargarCombo(ddlServicio, m_ssql, "idTipoServicio", "nombre");
 
             ///Carga de Sectores
-            m_ssql = "SELECT idSectorServicio, prefijo + ' - ' + nombre as nombre FROM LAB_SectorServicio with (nolock) WHERE (baja = 0) order by nombre";
+            m_ssql = @"SELECT idSectorServicio, prefijo + ' - ' + nombre as nombre FROM LAB_SectorServicio S with (nolock) WHERE (baja = 0) 
+                   and   exists (select 1 from Lab_SectorServicioEfector SE where SE.idSectorServicio = S.idSectorServicio and se.idefector = " + oUser.IdEfector.IdEfector.ToString() + @")  order by nombre";
             oUtil.CargarListBox(lstSector, m_ssql, "idSectorServicio", "nombre");
 
             for (int i = 0; i < lstSector.Items.Count; i++)

--- a/WebLab/ImpresionResult/ImprimirBusqueda.aspx.cs
+++ b/WebLab/ImpresionResult/ImprimirBusqueda.aspx.cs
@@ -11,16 +11,41 @@ using System.Web.UI.WebControls;
 using System.Web.UI.WebControls.WebParts;
 using System.Xml.Linq;
 using Business;
+using Business.Data;
 
 namespace WebLab.ImpresionResult
 {
     public partial class ImprimirBusqueda : System.Web.UI.Page
     {
+        
+        public Usuario oUser = new Usuario();
+
+        protected void Page_PreInit(object sender, EventArgs e)
+        {
+          
+            //MiltiEfector: Filtra para configuracion del efector del usuario 
+            if (Session["idUsuario"] != null)
+            {
+                oUser = (Usuario)oUser.Get(typeof(Usuario), int.Parse(Session["idUsuario"].ToString()));
+              
+            }
+            else Response.Redirect("../FinSesion.aspx", false);
+
+
+        }
+
         protected void Page_Load(object sender, EventArgs e)
         {
             if (!Page.IsPostBack)
             {
-               CargarPagina();
+                if (Session["idUsuario"] != null)
+                {
+                    CargarPagina();
+
+                }
+                else Response.Redirect("../FinSesion.aspx", false);
+
+               
             }
         }
 
@@ -203,7 +228,8 @@ namespace WebLab.ImpresionResult
             CargarArea();
 
             ///Carga de Sectores          
-            m_ssql = "SELECT idSectorServicio, prefijo + ' - ' + nombre as nombre FROM LAB_SectorServicio (nolock) WHERE (baja = 0) order by nombre";
+            m_ssql = @"SELECT idSectorServicio, prefijo + ' - ' + nombre as nombre FROM LAB_SectorServicio S (nolock) WHERE (baja = 0) 
+                     and exists (select 1 from Lab_SectorServicioEfector SE where SE.idSectorServicio = S.idSectorServicio and se.idefector = " + oUser.IdEfector.IdEfector.ToString() + @")  order by nombre";
             oUtil.CargarListBox(lstSector, m_ssql, "idSectorServicio", "nombre");
             for (int i = 0; i < lstSector.Items.Count; i++)
             {

--- a/WebLab/Informes/Informe.aspx.cs
+++ b/WebLab/Informes/Informe.aspx.cs
@@ -198,7 +198,9 @@ namespace WebLab.Informes
                 if (Request["Tipo"].ToString() == "HojaTrabajo") ddlPrioridad.SelectedValue = "1";//rutina
 
                 ///Carga de Sectores
-                m_ssql = "SELECT idSectorServicio, prefijo + ' - ' + nombre as nombre  FROM LAB_SectorServicio (nolock)  WHERE (baja = 0) order by nombre";
+                m_ssql = @"SELECT idSectorServicio, prefijo + ' - ' + nombre as nombre  FROM LAB_SectorServicio S with (nolock)  WHERE (baja = 0) 
+                         and   exists(select 1 from Lab_SectorServicioEfector SE where SE.idSectorServicio = S.idSectorServicio and se.idefector = "+oUser.IdEfector.IdEfector.ToString()+@")  order by nombre";
+                    
                 oUtil.CargarListBox(lstSector, m_ssql, "idSectorServicio", "nombre");
 
                 for (int i = 0; i < lstSector.Items.Count; i++)

--- a/WebLab/Items/ItemEdit2.aspx.cs
+++ b/WebLab/Items/ItemEdit2.aspx.cs
@@ -1057,15 +1057,17 @@ from Lab_ResultadoItem with (nolock) where baja=0 and idItem= " + Request["id"].
                 else
                     args.IsValid = true;
             }
-
+            //Caro: se saca el ingreso de observaciones, puede ir sin valor-
             if (rdbRango.Items[3].Selected)///solo observaciones
-            {
-                cvValores.ErrorMessage = "Debe ingresar una observación";
-                if (txtObservaciones.Text == "")
-                    args.IsValid = false;
-                else
-                    args.IsValid = true;
-            }
+                args.IsValid = true;
+            //if (rdbRango.Items[3].Selected)///solo observaciones
+            //{
+            //    cvValores.ErrorMessage = "Debe ingresar una observación";
+            //    if (txtObservaciones.Text == "")
+            //        args.IsValid = false;
+            //    else
+            //        args.IsValid = true;
+            //}
 
         }
 

--- a/WebLab/ParametrosEdit.aspx
+++ b/WebLab/ParametrosEdit.aspx
@@ -275,6 +275,19 @@ $("#tabContainer").tabs({ selected: currTab });
                                             </asp:DropDownList>
                                         </td>
                                     </tr>
+                                            <tr>
+                                        <td class="myLabelIzquierda">
+                                           Habilita Enfermedad Base :</td>
+                                        <td class="myLabelIzquierda">
+                                            
+                                            <asp:DropDownList ID="ddlEnfermedadBase" runat="server"  class="form-control input-sm" Width="100px"
+                                                
+                                                >
+                                                <asp:ListItem Selected="True" Value="0">No</asp:ListItem>
+                                                <asp:ListItem Value="1">Si</asp:ListItem>
+                                            </asp:DropDownList><small>Solo Microbiologia</small>
+                                        </td>
+                                    </tr>
                         
                                     <tr>
                                         <td class="myLabelIzquierda">
@@ -1680,6 +1693,16 @@ $("#tabContainer").tabs({ selected: currTab });
                                                 <img alt="" src="../App_Themes/default/images/excelPeq.gif"/>
                                                                 <asp:LinkButton ID="lnkExcel" runat="server" CssClass="myLittleLink" 
                                                                     onclick="lnkExcel_Click"  >Descargar Excel</asp:LinkButton>
+                                        </td>
+                                    </tr>
+                            <tr>
+                                        <td   >
+                                         <h6>  Mapeo SIL y SISA (Resultados): </h6>
+                                            </td>
+                                        <td    >
+                                                <img alt="" src="../App_Themes/default/images/excelPeq.gif"/>
+                                                                <asp:LinkButton ID="lnkExcelSISAResultados" runat="server" CssClass="myLittleLink" OnClick="lnkExcelSISAResultados_Click" 
+                                                                     >Descargar Excel</asp:LinkButton>
                                         </td>
                                     </tr>
 

--- a/WebLab/ParametrosEdit.aspx.cs
+++ b/WebLab/ParametrosEdit.aspx.cs
@@ -554,10 +554,17 @@ select * from areas order by nombre ";
                 else
                     ddlDiagnostico.SelectedValue = "0";
 
+                if (oC.HabilitaEnfermedadBase)
+                    ddlEnfermedadBase.SelectedValue = "1";
+                else
+                    ddlEnfermedadBase.SelectedValue = "0";
+
+
                 if (oC.MedicoObligatorio)
                     ddlMedicoObligatorio.SelectedValue = "1";
                 else
                     ddlMedicoObligatorio.SelectedValue = "0";
+
                 txtUrlMatriculacion.Text = oC.UrlMatriculacion;
                 string[] arr = oC.OrigenHabilitado.Split((",").ToCharArray());
                 foreach (string item in arr)
@@ -932,6 +939,25 @@ order by s.idEvento,s.idClasificacionManual,s.idGrupoEvento
             return Ds.Tables[0];
         }
 
+        private DataTable LeerDatosSISAResultados()
+        {
+
+            string m_strSQL = @"select I.codigo, I.nombre,  C.resultado as [Resultado SIL], idResultadoSISA as [Id Resultado SISA], nombreResultadoSISA  as [Resultado SISA]
+from LAB_ConfiguracionSISADetalle C with (nolock)
+inner join lab_item I with (nolock) on I.idItem= C.idItem
+order by I.codigo, I.nombre
+";
+
+            DataSet Ds = new DataSet();
+            SqlConnection conn = (SqlConnection)NHibernateHttpModule.CurrentSession.Connection;
+            SqlDataAdapter adapter = new SqlDataAdapter();
+            adapter.SelectCommand = new SqlCommand(m_strSQL, conn);
+            adapter.Fill(Ds);
+
+            return Ds.Tables[0];
+        }
+
+
 
         private bool SiNoHayProtocolosCargados()
       {
@@ -1034,7 +1060,12 @@ order by s.idEvento,s.idClasificacionManual,s.idGrupoEvento
 
               if (ddlDiagnostico.SelectedValue == "0") oC.DiagObligatorio = false;
               else oC.DiagObligatorio = true;
-              if (ddlPreValidacion.SelectedValue == "0") oC.PreValida = false;
+
+              
+                if (ddlEnfermedadBase.SelectedValue == "0") oC.HabilitaEnfermedadBase = false;
+                else oC.HabilitaEnfermedadBase = true;
+
+                if (ddlPreValidacion.SelectedValue == "0") oC.PreValida = false;
               else oC.PreValida = true;
 
               if (ddlNotificarSISA.SelectedValue == "0") oC.NotificarSISA = false;
@@ -1664,6 +1695,39 @@ order by s.idEvento,s.idClasificacionManual,s.idGrupoEvento
             MostrarDatos();
         }
 
+        protected void lnkExcelSISAResultados_Click(object sender, EventArgs e)
+        {
+            dataTableAExcelResultados(LeerDatosSISAResultados(), "MapeoSIL_SISA_Resultados");
+        }
+
+        private void dataTableAExcelResultados(DataTable tabla, string nombreArchivo)
+        {
+            if (tabla.Rows.Count > 0)
+            {
+                StringBuilder sb = new StringBuilder();
+                StringWriter sw = new StringWriter(sb);
+                HtmlTextWriter htw = new HtmlTextWriter(sw);
+                Page pagina = new Page();
+                HtmlForm form = new HtmlForm();
+                GridView dg = new GridView();
+                dg.EnableViewState = false;
+                dg.DataSource = tabla;
+                dg.DataBind();
+                pagina.EnableEventValidation = false;
+                pagina.DesignerInitialize();
+                pagina.Controls.Add(form);
+                form.Controls.Add(dg);
+                pagina.RenderControl(htw);
+                Response.Clear();
+                Response.Buffer = true;
+                Response.ContentType = "application/vnd.ms-excel";
+                Response.AddHeader("Content-Disposition", "attachment;filename=" + nombreArchivo + ".xls");
+                Response.Charset = "UTF-8";
+                Response.ContentEncoding = Encoding.Default;
+                Response.Write(sb.ToString());
+                Response.End();
+            }
+        }
         //protected void lnkImpresionPrueba_Click(object sender, EventArgs e)
         //{
         //    ImpresiondePrueba();

--- a/WebLab/ParametrosEdit.aspx.designer.cs
+++ b/WebLab/ParametrosEdit.aspx.designer.cs
@@ -166,6 +166,15 @@ namespace WebLab {
         protected global::System.Web.UI.WebControls.DropDownList ddlDiagnostico;
         
         /// <summary>
+        /// ddlEnfermedadBase control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.DropDownList ddlEnfermedadBase;
+        
+        /// <summary>
         /// ddlRecordarOrigenProtocolo control.
         /// </summary>
         /// <remarks>
@@ -938,6 +947,15 @@ namespace WebLab {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.LinkButton lnkExcel;
+        
+        /// <summary>
+        /// lnkExcelSISAResultados control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.LinkButton lnkExcelSISAResultados;
         
         /// <summary>
         /// btnReinializacion control.

--- a/WebLab/Protocolos/Default2.aspx
+++ b/WebLab/Protocolos/Default2.aspx
@@ -99,9 +99,10 @@
 					
 					<tr>
 						<td class="myLabelIzquierda"  style="width: 150px">
-                                            Sexo:<asp:RangeValidator ID="rvSexo" runat="server" 
+                                            Sexo:
+                            <%--<asp:RangeValidator ID="rvSexo" runat="server" 
                                 ControlToValidate="ddlSexo" ErrorMessage="Sexo" MaximumValue="999999" 
-                                MinimumValue="1" Type="Integer" ValidationGroup="0">*</asp:RangeValidator>
+                                MinimumValue="1" Type="Integer" ValidationGroup="0">*</asp:RangeValidator>--%>
                                         </td>
 						<td align="left" colspan="2">
                                             <asp:DropDownList ID="ddlSexo" runat="server" TabIndex="2" class="form-control input-sm">
@@ -112,6 +113,7 @@
                                                 <asp:ListItem Value="4">X-No Binario</asp:ListItem>
                                              
                                             </asp:DropDownList>
+                                            <asp:Label ID="lblMensajeSexo" runat="server" Font-Bold="True" ForeColor="#CC3300" Visible="False"></asp:Label>
                         </td>
 						<td rowspan="5" >   </td>
 					</tr>
@@ -204,7 +206,7 @@
 						<td  colspan="4" >					
 
                              
-                            <asp:Label ID="lblMensaje" runat="server" ForeColor="Red" Text="Se encontraron los siguientes datos para el dni ingresado:" Visible="False"></asp:Label>
+                            <asp:Label ID="lblMensaje" runat="server" ForeColor="Blue" Text="Se encontraron los siguientes datos para el dni ingresado:" Visible="False"></asp:Label>
                             <asp:GridView ID="gvLista" runat="server" AllowPaging="True" AutoGenerateColumns="False" CellPadding="1" CssClass="table table-bordered bs-table" DataKeyNames="idPaciente" EmptyDataText="No se encontraron pacientes para los parametros de busqueda ingresados" Font-Size="9pt" ForeColor="#666666" GridLines="Horizontal" onpageindexchanging="gvLista_PageIndexChanging" onrowcommand="gvLista_RowCommand" onrowdatabound="gvLista_RowDataBound" PageSize="13" Width="100%">
                <%--<RowStyle BackColor="#F7F6F3" ForeColor="Black" Font-Names="Arial" 
                 Font-Size="8pt" />--%>

--- a/WebLab/Protocolos/Default2.aspx.cs
+++ b/WebLab/Protocolos/Default2.aspx.cs
@@ -363,14 +363,14 @@ namespace WebLab.Protocolos
         }
         private void CargarGrilla ()
         {
-            string m_sexo = "F";
-            if (ddlSexo.SelectedValue == "2")
-                m_sexo = "F";
+            string m_sexo = ""; lblMensajeSexo.Visible = false; lblMensaje.Visible = false;
+            //if (ddlSexo.SelectedValue == "2")
+            //    m_sexo = "F";
 
-            if (ddlSexo.SelectedValue == "3")
-                m_sexo = "M";
-            if (ddlSexo.SelectedValue == "4")
-                m_sexo = "X";
+            //if (ddlSexo.SelectedValue == "3")
+            //    m_sexo = "M";
+            //if (ddlSexo.SelectedValue == "4")
+            //    m_sexo = "X";
 
 
 
@@ -382,12 +382,22 @@ namespace WebLab.Protocolos
 
                 if (gvLista.Rows.Count == 0)
                 {
-                    lblMensaje.Visible = false;
+                    if (ddlSexo.SelectedValue != "0")  // se debe seleccionar el sexo para generar un paciente nuevo
+                    {
+                        m_sexo = obtenerSexo();                       
+                        lblMensaje.Visible = false;
 
-                    if (Request["Operacion"] != "Modifica")
-                        Response.Redirect("ProcesaRenaper.aspx?Tipo=" + ddlTipo.SelectedValue + "&dni=" + txtDni.Value + "&sexo=" + m_sexo + "&llamada=LaboProtocolo&idServicio=" + Request["idServicio"].ToString() + "&idUrgencia=" + Session["idUrgencia"].ToString());
+                        if (Request["Operacion"] != "Modifica")
+                            Response.Redirect("ProcesaRenaper.aspx?Tipo=" + ddlTipo.SelectedValue + "&dni=" + txtDni.Value + "&sexo=" + m_sexo + "&llamada=LaboProtocolo&idServicio=" + Request["idServicio"].ToString() + "&idUrgencia=" + Session["idUrgencia"].ToString());
+                        else
+                            Response.Redirect("ProcesaRenaper.aspx?Tipo=" + ddlTipo.SelectedValue + "&dni=" + txtDni.Value + "&sexo=" + m_sexo + "&llamada=LaboProtocolo&idServicio=" + Request["idServicio"].ToString() + "&idUrgencia=" + Session["idUrgencia"].ToString() + "&Operacion=" + Request["Operacion"].ToString() + "&idProtocolo=" + Request["idProtocolo"].ToString() + "&Desde=" + Request["Desde"].ToString());
+                    }
                     else
-                        Response.Redirect("ProcesaRenaper.aspx?Tipo=" + ddlTipo.SelectedValue + "&dni=" + txtDni.Value + "&sexo=" + m_sexo + "&llamada=LaboProtocolo&idServicio=" + Request["idServicio"].ToString() + "&idUrgencia=" + Session["idUrgencia"].ToString()+ "&Operacion=" + Request["Operacion"].ToString() + "&idProtocolo="+ Request["idProtocolo"].ToString() + "&Desde=" + Request["Desde"].ToString());
+                    {
+                        lblMensajeSexo.Text = "Debe ingresar un sexo para generar un paciente nuevo";
+                        lblMensajeSexo.Visible = true;
+                        lblMensaje.Visible = false;
+                    }
 
                 }
                 else
@@ -397,32 +407,53 @@ namespace WebLab.Protocolos
 
             if ((ddlTipo.SelectedValue == "T"))
             { //temporal
+
+
                 if ((txtDni.Value != "") || (txtNumeroAdicional.Text != ""))
                 {
                     gvLista.DataSource = LeerDatos();
                     gvLista.DataBind();
-
-
                     if (gvLista.Rows.Count == 0)
                     {
-                        lblMensaje.Visible = false;
-
-                        if (Request["Operacion"] != "Modifica")
-                            Response.Redirect("ProcesaRenaperT.aspx?Tipo=" + ddlTipo.SelectedValue + "&dni=" + txtDni.Value + "&sexo=" + m_sexo + "&llamada=LaboProtocolo&idServicio=" + Request["idServicio"].ToString() + "&idUrgencia=" + Session["idUrgencia"].ToString());
+                        if (ddlSexo.SelectedValue != "0")  // se debe seleccionar el sexo para generar un paciente nuevo
+                        {
+                            m_sexo = obtenerSexo();
+                            lblMensaje.Visible = false;
+                            if (Request["Operacion"] != "Modifica")
+                                Response.Redirect("ProcesaRenaperT.aspx?Tipo=" + ddlTipo.SelectedValue + "&dni=" + txtDni.Value + "&sexo=" + m_sexo + "&llamada=LaboProtocolo&idServicio=" + Request["idServicio"].ToString() + "&idUrgencia=" + Session["idUrgencia"].ToString());
+                            else
+                                Response.Redirect("ProcesaRenaperT.aspx?Tipo=" + ddlTipo.SelectedValue + "&dni=" + txtDni.Value + "&sexo=" + m_sexo + "&llamada=LaboProtocolo&idServicio=" + Request["idServicio"].ToString() + "&idUrgencia=" + Session["idUrgencia"].ToString() + "&Operacion=" + Request["Operacion"].ToString() + "&idProtocolo=" + Request["idProtocolo"].ToString() + "&Desde=" + Request["Desde"].ToString());
+                        }
                         else
-                            Response.Redirect("ProcesaRenaperT.aspx?Tipo=" + ddlTipo.SelectedValue + "&dni=" + txtDni.Value + "&sexo=" + m_sexo + "&llamada=LaboProtocolo&idServicio=" + Request["idServicio"].ToString() + "&idUrgencia=" + Session["idUrgencia"].ToString() + "&Operacion=" + Request["Operacion"].ToString() + "&idProtocolo=" + Request["idProtocolo"].ToString() + "&Desde=" + Request["Desde"].ToString());
+                        {
 
+                            lblMensajeSexo.Text = "Debe ingresar un sexo para generar un paciente nuevo";
+                            lblMensajeSexo.Visible = true;
+                            lblMensaje.Visible = false;
+                        }
                     }
                     else
                         lblMensaje.Visible = true;
                 }
 
                 else
+                {
+                    if (ddlSexo.SelectedValue != "0")  // se debe seleccionar el sexo para generar un paciente nuevo
+                    {
+                        m_sexo = obtenerSexo();
 
-                    Response.Redirect("ProcesaRenaperT.aspx?Tipo=" + ddlTipo.SelectedValue + "&dni=" + txtDni.Value + "&sexo=" + m_sexo + "&llamada=LaboProtocolo&idServicio=" + Request["idServicio"].ToString() + "&idUrgencia=" + Session["idUrgencia"].ToString());
+
+                        Response.Redirect("ProcesaRenaperT.aspx?Tipo=" + ddlTipo.SelectedValue + "&dni=" + txtDni.Value + "&sexo=" + m_sexo + "&llamada=LaboProtocolo&idServicio=" + Request["idServicio"].ToString() + "&idUrgencia=" + Session["idUrgencia"].ToString());
+                    }
+                    else
+                    {
+                        lblMensajeSexo.Text = "Debe ingresar un sexo para generar un paciente nuevo";
+                        lblMensajeSexo.Visible = true;
+                    }
+                }
+
+
             }
-
-
 
 
 
@@ -439,6 +470,17 @@ namespace WebLab.Protocolos
 
         }
 
+        private string obtenerSexo()
+        {
+            string m_sexo="";
+            if (ddlSexo.SelectedValue == "2")
+                m_sexo = "F";
+            if (ddlSexo.SelectedValue == "3")
+                m_sexo = "M";
+            if (ddlSexo.SelectedValue == "4")
+                m_sexo = "X";
+            return m_sexo;
+        }
 
         private object LeerDatos()
         {

--- a/WebLab/Protocolos/Default2.aspx.designer.cs
+++ b/WebLab/Protocolos/Default2.aspx.designer.cs
@@ -121,15 +121,6 @@ namespace WebLab.Protocolos {
         protected global::System.Web.UI.WebControls.CompareValidator cvDni;
         
         /// <summary>
-        /// rvSexo control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.WebControls.RangeValidator rvSexo;
-        
-        /// <summary>
         /// ddlSexo control.
         /// </summary>
         /// <remarks>
@@ -137,6 +128,15 @@ namespace WebLab.Protocolos {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.DropDownList ddlSexo;
+        
+        /// <summary>
+        /// lblMensajeSexo control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Label lblMensajeSexo;
         
         /// <summary>
         /// txtNumeroAdicional control.

--- a/WebLab/Protocolos/DerivacionMultiEfectorLote.aspx.cs
+++ b/WebLab/Protocolos/DerivacionMultiEfectorLote.aspx.cs
@@ -42,7 +42,7 @@ namespace WebLab.Protocolos
             if (!Page.IsPostBack)
             {
 
-                VerificaPermisos("Derivacion");
+                VerificaPermisos("Derivacion por Lotes");
                 if (Request["idServicio"].ToString() != "5")
                     ProtocoloList1.CargarGrillaProtocolo(Request["idServicio"].ToString());
                 else

--- a/WebLab/Protocolos/DerivacionRecibirLote.aspx.cs
+++ b/WebLab/Protocolos/DerivacionRecibirLote.aspx.cs
@@ -38,7 +38,7 @@ namespace WebLab.Protocolos
         {
             if (!Page.IsPostBack)
             {
-                VerificaPermisos("Derivacion");
+                VerificaPermisos("Derivacion por Lotes");
                 CargarEncabezado();
             }
         }

--- a/WebLab/Protocolos/ProtocoloEdit2.aspx
+++ b/WebLab/Protocolos/ProtocoloEdit2.aspx
@@ -643,7 +643,7 @@
                                              <td class="auto-style1">                                               
                                             
                                                Diagnósticos encontrados<anthem:ListBox ID="lstDiagnosticos" runat="server" AutoCallBack="True" 
-                                                     class="form-control input-sm"  Height="100px" Width="750px">
+                                                     class="form-control input-sm"  Height="90px" Width="750px">
                                                </anthem:ListBox>
                                                  <anthem:Label ID="lblMensajeDiagnostico" runat="server" Visible="false" Text="Label" Font-Bold="True" ForeColor="#CC0000"></anthem:Label>
 
@@ -660,18 +660,11 @@
                                              </td>   
                                 
                                 </tr>
-                                <tr>
-                                             <td class="auto-style1">
-                                                 <p  >Diagnósticos del Paciente</p>
-                                                 </td>                                         
-                                             <td style="vertical-align: top">
-                                                 &nbsp;</td>   
                                 
-                                </tr>
                                 <tr>
-                                             <td class="auto-style1">
+                                             <td class="auto-style1">Diagnósticos del Paciente
                                                  <anthem:ListBox ID="lstDiagnosticosFinal" runat="server"    class="form-control input-sm"
-                                                     Height="100px" Width="650px" SelectionMode="Multiple">
+                                                     Height="90px" Width="750px" SelectionMode="Multiple">
                                                  </anthem:ListBox></td>                                         
                                              <td style="vertical-align: top">
                                     
@@ -689,17 +682,31 @@
                                                                                            
                                         &nbsp; <input id="txtFechaFIS" runat="server" type="text" maxlength="10" 
                         style="width: 120px"  onblur="valFecha(this)" 
-                        onkeyup="mascara(this,'/',patron,true)" tabindex="1" class="form-control input-sm"  />
+                        onkeyup="mascara(this,'/',patron,true)" tabindex="1" class="form-control input-sm"  title="Fecha de inicio de sintomas" />
                                                    <asp:CheckBox ID="chkSinFIS" runat="server" Text="Sin informar" />
                                                    &nbsp;&nbsp;&nbsp;&nbsp;
                                                   <anthem:Label ID="Label1" runat="server" Text="FUC:"></anthem:Label>
                                                             &nbsp;                                
                                         <input id="txtFechaFUC" runat="server" type="text" maxlength="10" 
                         style="width: 120px"  onblur="valFecha(this)" 
-                        onkeyup="mascara(this,'/',patron,true)" tabindex="1" class="form-control input-sm"  />  <asp:CheckBox ID="chkSinFUC" runat="server" Text="Sin informar" />
+                        onkeyup="mascara(this,'/',patron,true)" tabindex="1" class="form-control input-sm"  title="Fecha de Ultimo Control" />  <asp:CheckBox ID="chkSinFUC" runat="server" Text="Sin informar" />
                                                </div></td>                                         
                                              <td style="vertical-align: top">
                                                  &nbsp;</td>   
+                                
+                                </tr>
+                                      <tr>
+                                             <td colspan="5"  >  
+						<asp:Panel   runat="server" ID="pnlEnfermedadBase" Visible="false" Width="100%">
+                            <hr />
+                                                 <anthem:Label ID="lblEB" runat="server" Text="Enfermedad Base:"></anthem:Label>
+                                                                                           
+                                        
+                                                 <anthem:TextBox ID="txtCodigoEnfermedadBase" Width="60px" TabIndex="12" class="form-control input-sm" runat="server"   AutoCallBack="true" OnTextChanged="txtCodigoEnfermedadBase_TextChanged"></anthem:TextBox> 
+                            <anthem:DropDownList ID="ddlEnfermedadBase" Width="400px" runat="server" TabIndex="13"  AutoCallBack="true"    class="form-control input-sm" OnSelectedIndexChanged="ddlEnfermedadBase_SelectedIndexChanged" >
+                            </anthem:DropDownList>
+                            </asp:Panel>
+                            </td>   
                                 
                                 </tr>
                                 </table>
@@ -890,7 +897,6 @@
             const txtDatos = document.getElementById('<%= Page.Master.FindControl("ContentPlaceHolder1").FindControl("TxtDatos").ClientID %>').value;
 
             if (redirect) {
-                
                 if (!postBack) AgregarCargados(); //Recarga todo desde cero
                 else AgregarCargadoSinVerificar(); //Si da error de postback se debe cargar nuevamente sin verificar
             } else {
@@ -1226,6 +1232,7 @@
                 OrdenarDatos();
 
                 contadorfilas = contadorfilas - 1;
+                document.getElementById('<%= Page.Master.FindControl("ContentPlaceHolder1").FindControl("TxtCantidadFilas").ClientID %>').value = contadorfilas; //para no perder el valor luego de un postback
             }
             else {
 
@@ -1270,7 +1277,7 @@
                     }
 
                     pos = pos + 1;
-                    str = str + nroFila.value + '#' + cod.value + '#' + tarea.value + '#' + desde.value + '#' + estado + '@';
+                    str = str + nroFila.value + '#' + cod.value + '#' + tarea.value + '#' + desde.checked + '#' + estado + '@';
                 }
             }
             document.getElementById('<%= Page.Master.FindControl("ContentPlaceHolder1").FindControl("TxtDatos").ClientID %>').value = str;

--- a/WebLab/Protocolos/ProtocoloEdit2.aspx
+++ b/WebLab/Protocolos/ProtocoloEdit2.aspx
@@ -1232,7 +1232,7 @@
                 OrdenarDatos();
 
                 contadorfilas = contadorfilas - 1;
-                document.getElementById('<%= Page.Master.FindControl("ContentPlaceHolder1").FindControl("TxtCantidadFilas").ClientID %>').value = contadorfilas; //para no perder el valor luego de un postback
+                document.getElementById('<%= Page.Master.FindControl("ContentPlaceHolder1").FindControl("TxtCantidadFilas").ClientID %>').value = contadorfilas;
             }
             else {
 
@@ -1266,6 +1266,7 @@
                     var desde = document.getElementById('Desde_' + i);
                     desde.name = 'Desde_' + pos;
                     desde.id = 'Desde_' + pos;
+                    
                     var estado = 0;
 
                     if (cod != null) { //si no es la ultima fila

--- a/WebLab/Protocolos/ProtocoloEdit2.aspx
+++ b/WebLab/Protocolos/ProtocoloEdit2.aspx
@@ -1226,6 +1226,7 @@
                 OrdenarDatos();
 
                 contadorfilas = contadorfilas - 1;
+                document.getElementById('<%= Page.Master.FindControl("ContentPlaceHolder1").FindControl("TxtCantidadFilas").ClientID %>').value = contadorfilas;
             }
             else {
 
@@ -1259,6 +1260,7 @@
                     var desde = document.getElementById('Desde_' + i);
                     desde.name = 'Desde_' + pos;
                     desde.id = 'Desde_' + pos;
+                    
                     var estado = 0;
 
                     if (cod != null) { //si no es la ultima fila
@@ -1270,7 +1272,7 @@
                     }
 
                     pos = pos + 1;
-                    str = str + nroFila.value + '#' + cod.value + '#' + tarea.value + '#' + desde.value + '#' + estado + '@';
+                    str = str + nroFila.value + '#' + cod.value + '#' + tarea.value + '#' + desde.checked + '#' + estado + '@';
                 }
             }
             document.getElementById('<%= Page.Master.FindControl("ContentPlaceHolder1").FindControl("TxtDatos").ClientID %>').value = str;

--- a/WebLab/Protocolos/ProtocoloEdit2.aspx.cs
+++ b/WebLab/Protocolos/ProtocoloEdit2.aspx.cs
@@ -796,6 +796,9 @@ namespace WebLab.Protocolos
             oRegistro = (Business.Data.Laboratorio.Protocolo)oRegistro.Get(typeof(Business.Data.Laboratorio.Protocolo), int.Parse(Request["idProtocolo"].ToString()));
             if (oRegistro != null)
             {
+                // si es modificacion no se recuerda analisis
+                chkRecordarPractica.Visible = false;
+                //fin si es modificacion no se recuerda analisis
                 oRegistro.GrabarAuditoriaProtocolo("Consulta", int.Parse(Session["idUsuario"].ToString()));                 
                 if (oRegistro.IdTipoServicio.IdTipoServicio == 6)
                 {
@@ -1031,7 +1034,8 @@ namespace WebLab.Protocolos
 
 
                 MostrarDiagnosticos(oRegistro);
-           
+                //muestra enfermedad base
+                MostrarEnfermedadBase(oRegistro);
 
 
                 //chkRecordarConfiguracion.Checked = false;
@@ -1055,9 +1059,9 @@ namespace WebLab.Protocolos
             {
 
                 string m_strSQL = @"select c.id, c.codigo + ' -' + c.nombre 
-from sys_cie10 c (nolock)
-inner join LAB_ProtocoloDiagnostico pd (nolock) on c.id = pd.idDiagnostico
-where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
+from sys_cie10 c with (nolock)
+inner join LAB_ProtocoloDiagnostico pd with (nolock) on c.id = pd.idDiagnostico
+where  pd.tipo='D' and pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
 
             DataSet Ds = new DataSet();
             SqlConnection conn = new SqlConnection(ConfigurationManager.ConnectionStrings["SIL_ReadOnly"].ConnectionString); ///Performance: conexion de solo lectura
@@ -1153,8 +1157,40 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
              
         }
 
+        private void MostrarEnfermedadBase(Protocolo oRegistro)
+        {
 
-      
+            Utility oUtil = new Utility();
+            string m_strSQL = @"select top 1 c.id, c.codigo 
+from sys_cie10 c with (nolock)
+inner join LAB_ProtocoloDiagnostico pd with (nolock) on c.id = pd.idDiagnostico
+where pd.tipo='B' and pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
+
+                DataSet Ds = new DataSet();
+                SqlConnection conn = new SqlConnection(ConfigurationManager.ConnectionStrings["SIL_ReadOnly"].ConnectionString); ///Performance: conexion de solo lectura
+                SqlDataAdapter adapter = new SqlDataAdapter();
+                adapter.SelectCommand = new SqlCommand(m_strSQL, conn);
+                adapter.Fill(Ds);
+                
+                for (int i = 0; i < Ds.Tables[0].Rows.Count; i++)
+            {
+                if (!oC.HabilitaEnfermedadBase)
+                {
+                    CargarListaEnfermedadesBase();
+
+                }
+                string s_id=Ds.Tables[0].Rows[i][0].ToString();
+                string s_codigo= Ds.Tables[0].Rows[i][1].ToString();
+                ddlEnfermedadBase.SelectedValue = s_id;                
+                txtCodigoEnfermedadBase.Text = s_codigo;
+                txtCodigoEnfermedadBase.UpdateAfterCallBack=true;
+                ddlEnfermedadBase.UpdateAfterCallBack = true;
+
+                         }                
+
+        }
+
+
 
 
 
@@ -1294,30 +1330,7 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
             string connReady = ConfigurationManager.ConnectionStrings["SIL_ReadOnly"].ConnectionString; ///Performance: conexion de solo lectura
 
             ddlMuestra.Items.Insert(0, new ListItem("--Seleccione Muestra--", "0"));
-            pnlMuestra.Visible = false;
-
-            //if (int.Parse(Session["idServicio"].ToString()) == 1)
-            //{
-            //    pnlComprobantePaciente.Visible = oC.GeneraComprobanteProtocolo;
-            //    lblImprimeComprobantePaciente.Enabled = oC.GeneraComprobanteProtocolo;
-            //    chkImprimir.Enabled = oC.GeneraComprobanteProtocolo;                                
-            //    ddlImpresora.Enabled = oC.GeneraComprobanteProtocolo;
-            //    lnkReimprimirComprobante.Enabled = oC.GeneraComprobanteProtocolo;
-            //    lnkReimprimirCodigoBarras.Enabled = oC.GeneraComprobanteProtocolo;
-
-            //}
-
-            //if (int.Parse(Session["idServicio"].ToString()) == 3)
-            //{
-            //    pnlComprobantePaciente.Visible = oC.GeneraComprobanteProtocoloMicrobiologia;
-            //    lblImprimeComprobantePaciente.Enabled = oC.GeneraComprobanteProtocoloMicrobiologia;                
-            //    chkImprimir.Enabled = oC.GeneraComprobanteProtocoloMicrobiologia;                
-            //    ddlImpresora.Enabled = oC.GeneraComprobanteProtocoloMicrobiologia;
-            //    lnkReimprimirComprobante.Enabled = oC.GeneraComprobanteProtocoloMicrobiologia;
-            //    lnkReimprimirCodigoBarras.Enabled = oC.GeneraComprobanteProtocoloMicrobiologia;
-            //}
-
-
+            pnlMuestra.Visible = false;         
 
 
             ///Carga de combos de tipos de servicios          
@@ -1327,15 +1340,33 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
 
 
             ///Carga de grupos de numeración solo si el tipo de numeración es 2: por Grupos
-            string m_ssql = "SELECT  idSectorServicio,  prefijo + ' - ' + nombre   as nombre FROM LAB_SectorServicio  with (nolock) WHERE (baja = 0) order by nombre";
+            //string m_ssql = "SELECT  idSectorServicio,  prefijo + ' - ' + nombre   as nombre FROM LAB_SectorServicio  with (nolock) WHERE (baja = 0) order by nombre";
+
+            //oUtil.CargarCombo(ddlSectorServicio, m_ssql, "idSectorServicio", "nombre", connReady);
+            //ddlSectorServicio.Items.Insert(0, new ListItem("Seleccione", "0"));
+            //if (oC.IdSectorDefecto > 0)
+            //{
+            //    ddlSectorServicio.SelectedValue = oC.IdSectorDefecto.ToString();
+            //  //  ddlSectorServicio.Visible = false;
+            //}
+
+            ///Carga de grupos de numeración solo si el tipo de numeración es 2: por Grupos
+            string str_condicion = ")";
+            if ((Request["Operacion"].ToString() == "Modifica") && (Request["idProtocolo"]!=null))
+             str_condicion = "  or exists (select 1 from LAB_Protocolo p WHERE p.idsector  = s.idSectorServicio and idProtocolo = " + Request["idProtocolo"].ToString() + ")) ";
+
+
+            string m_ssql = @"SELECT  s.idSectorServicio,  s.prefijo + ' - ' + s.nombre   as nombre FROM LAB_SectorServicio  S with (nolock) 
+                             WHERE (baja = 0)  
+                             and ( exists (select 1 from Lab_SectorServicioEfector SE where SE.idSectorServicio=S.idSectorServicio and se.idefector="+oUser.IdEfector.IdEfector.ToString()+@" )" + str_condicion +@" order by nombre";
 
             oUtil.CargarCombo(ddlSectorServicio, m_ssql, "idSectorServicio", "nombre", connReady);
             ddlSectorServicio.Items.Insert(0, new ListItem("Seleccione", "0"));
-            if (oC.IdSectorDefecto > 0)
+        /*    if (oC.IdSectorDefecto > 0)
             {
                 ddlSectorServicio.SelectedValue = oC.IdSectorDefecto.ToString();
-              //  ddlSectorServicio.Visible = false;
-            }
+                //  ddlSectorServicio.Visible = false;
+            }*/
 
             /////////////////////////////////////////////CODIGO DE BARRAS//////////////////////////////////////////////////////////////////////
             tab3Titulo.Visible = false;
@@ -1455,7 +1486,14 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
                 m_ssql += " order by nombre ";
                 oUtil.CargarCombo(ddlMuestra, m_ssql, "idMuestra", "nombre", connReady);
                 ddlMuestra.Items.Insert(0, new ListItem("--Seleccione Muestra--", "0"));
-                
+
+                ////Carga de combo de enfermedad base
+                if (oC.HabilitaEnfermedadBase) 
+                {
+                    CargarListaEnfermedadesBase();
+                    
+                }
+                else pnlEnfermedadBase.Visible = false;
 
             }
 
@@ -1569,6 +1607,19 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
             oUtil = null;
         }
 
+        private void CargarListaEnfermedadesBase()
+        {
+            Utility oUtil = new Utility();
+            //Configuracion oC = new Configuracion(); oC = (Configuracion)oC.Get(typeof(Configuracion), "IdConfiguracion", 1);
+
+            string connReady = ConfigurationManager.ConnectionStrings["SIL_ReadOnly"].ConnectionString; ///Performance: conexion de solo lectura
+
+            pnlEnfermedadBase.Visible = true;
+            string m_ssql = @"select id as idDiag, nombre + ' - ' + codigo as nombre   from sys_cie10 with (nolock) where tipo='BASE' order by nombre ";
+            oUtil.CargarCombo(ddlEnfermedadBase, m_ssql, "idDiag", "nombre", connReady);
+            ddlEnfermedadBase.Items.Insert(0, new ListItem("--Seleccione Enfermedad Base--", "0"));
+        }
+
         private void IniciarValores(Configuracion oC)
         {
             if (Session["ProtocoloLaboratorio"] != null)
@@ -1664,8 +1715,8 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
                                     chkRecordarPractica.Checked = true;
                             }
                             break;
-                        case "prácticas":
-                            TxtDatosCargados.Value = s_control[1].ToString(); break;
+                        case "prácticas":   if(Request["idServicio"] == "1") TxtDatosCargados.Value = s_control[1].ToString(); break;
+                        case "prácticasMicro":   if(Request["idServicio"] == "3")  TxtDatosCargados.Value = s_control[1].ToString(); break;
                         //case "ddlImpresora":
                         //    ddlImpresora.SelectedValue = s_control[1].ToString(); break;
 
@@ -1777,9 +1828,7 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
                         }
 
 
-
-                        /////////////////
-
+                        EnviarEquipo(oRegistro);
 
                         ///Imprimir codigo de barras.
                         //string s_AreasCodigosBarras = getListaAreasCodigoBarras();
@@ -1893,6 +1942,44 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
             }
            
 
+        }
+
+        private void EnviarEquipo(Protocolo oRegistro)
+        {
+            /*
+                    Caro: Primer version para enviar de forma automatica (sin intervencion del usuario) muestras el equipo.
+                    En este caso para el equipo REAL: Si el servicio es micro solo para los efectores 205 y 221 (HPN y HEller)
+                    Se debe mejorar para algo mas generico
+                    Se agrega try/cath para que ante cualquier problema no haya inconvenientes con el ingreso de la muestra
+                    */
+
+            try
+            {
+                if ((oRegistro.IdTipoServicio.IdTipoServicio == 3) &&
+                    (oRegistro.IdEfector.IdEfector == 205 || oRegistro.IdEfector.IdEfector == 221))
+                {
+                    using (SqlConnection conn = (SqlConnection)NHibernateHttpModule.CurrentSession.Connection)
+                    {
+
+                        using (SqlCommand cmd = new SqlCommand("dbo.LAB_GeneraProtocoloEnvioAutomaticoREAL", conn))
+                        {
+                            cmd.CommandType = CommandType.StoredProcedure;
+
+                            // Parámetros del SP
+                            cmd.Parameters.AddWithValue("@idEfector", oRegistro.IdEfector.IdEfector);
+                            cmd.Parameters.AddWithValue("@idProtocolo", oRegistro.IdProtocolo);
+
+                            // Ejecuta sin devolver resultados
+                            cmd.ExecuteNonQuery();
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                string exception = "";
+                exception = ex.Message + "<br>";
+            }
         }
 
         private void ActualizarEstadoDerivacion(Protocolo oRegistro, Protocolo oRegistroAnterior)
@@ -2087,7 +2174,7 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
         //        ticket.AddSubHeaderLine("PRACTICAS SOLICITADAS");
         //        for (int i = 1; i <= cantidadFilas; i++)
         //        {
-        //            int td = i * 90;
+        //            int l = i * 90;
         //            analisis = analisis.Insert(l, "&");
 
         //        }
@@ -2335,6 +2422,8 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
 
                 //   if (Request["idSolicitudScreening"] != null) ActualizarSolicitudScreening(Request["idSolicitudScreening"].ToString(),oRegistro);
                 GuardarDiagnosticos(oRegistro);
+                if (oRegistro.IdTipoServicio.IdTipoServicio==3) GuardarEnfermedadBase(oRegistro);
+
                 GuardarDetalle(oRegistro);
                 //GuardarDiagnosticos(oRegistro);
                 this.IncidenciaEdit1.GuardarProtocoloIncidencia(oRegistro);
@@ -2441,6 +2530,63 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
             return guardo;
         }
 
+      
+
+
+        private void GuardarEnfermedadBase(Protocolo oRegistro)
+        {
+            if ((ddlEnfermedadBase.SelectedValue != "0")&& (ddlEnfermedadBase.SelectedValue != ""))
+            {
+                int nuevoIdDiagnostico = int.Parse(ddlEnfermedadBase.SelectedValue);
+                string nuevoNombre = ddlEnfermedadBase.SelectedItem.Text;
+                string accion = "Graba";
+
+                ISession m_session = NHibernateHttpModule.CurrentSession;
+
+                // Buscar si ya existe un registro de enfermedad base
+                ICriteria crit = m_session.CreateCriteria(typeof(ProtocoloDiagnostico));
+                crit.Add(Expression.Eq("IdProtocolo", oRegistro));
+                crit.Add(Expression.Eq("Tipo", "B")); // enfermedad base
+                IList detalleExistente = crit.List();
+
+                if (detalleExistente.Count > 0)
+                {
+                    ProtocoloDiagnostico existente = (ProtocoloDiagnostico)detalleExistente[0];
+
+                    // Verificar si es distinto al seleccionado
+                    if (existente.IdDiagnostico != nuevoIdDiagnostico)
+                    {
+                        // Eliminar el registro anterior
+                        existente.Delete();
+
+                        // Crear el nuevo registro
+                        ProtocoloDiagnostico oDetalle = new ProtocoloDiagnostico();
+                        oDetalle.IdProtocolo = oRegistro;
+                        oDetalle.IdEfector = oRegistro.IdEfector;
+                        oDetalle.IdDiagnostico = nuevoIdDiagnostico;
+                        oDetalle.Tipo = "B";
+                        oDetalle.Save();
+
+                        accion = "Cambia";
+                        oDetalle.IdProtocolo.GrabarAuditoriaDetalleProtocolo(accion, int.Parse(Session["idUsuario"].ToString()), "Enfermedad Base", nuevoNombre);
+                    }
+                    // Si es igual, no hacer nada
+                }
+                else
+                {
+                    // No existe registro previo, crear uno nuevo
+                    ProtocoloDiagnostico oDetalle = new ProtocoloDiagnostico();
+                    oDetalle.IdProtocolo = oRegistro;
+                    oDetalle.IdEfector = oRegistro.IdEfector;
+                    oDetalle.IdDiagnostico = nuevoIdDiagnostico;
+                    oDetalle.Tipo = "B";
+                    oDetalle.Save();
+
+                    oDetalle.IdProtocolo.GrabarAuditoriaDetalleProtocolo(accion, int.Parse(Session["idUsuario"].ToString()), "Enfermedad Base", nuevoNombre);
+                }
+            }
+        }
+
         //private void ActualizarSolicitudScreening(string p, Protocolo oProtocolo)
         //{
         //    SolicitudScreening oRegistro = new SolicitudScreening();
@@ -2496,13 +2642,42 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
                     {
                         s_valores += "@ddlSectorServicio:" + ddlSectorServicio.SelectedValue;            
                     }                                                                                      
+///caro: ver si dejar
+            if (chkRecordarPractica.Checked)
+            {//guardo la sesion de general y microbiologia por si vuelvo a cargar esos tipos de labos, luego en GuardarDetalle se actualizan si el usuario lo cambio
+                if(Session["ProtocoloLaboratorio"] != null)
+                {
+                    string[] arr = Session["ProtocoloLaboratorio"].ToString().Split(("@").ToCharArray());
+                    foreach (string item in arr)
+                    {
+                        string[] s_control = item.Split((":").ToCharArray());
+                        switch (s_control[0].ToString()) {
 
+                            case "prácticas":
+                                string practicas = "@prácticas:" + s_control[1].ToString();
+                                if (Request["idServicio"] == "1") 
+                                    s_valores = s_valores.Replace(practicas, ""); //si es laboratorio general lo borro y lo cargo en GuardarDetalle.
+                                else
+                                        s_valores += practicas; //si no es laboratorio general no quiero perder su session "prácticas"
+                                break;
+
+                            case "prácticasMicro":
+                                string practicasMicro = "@prácticasMicro:" + s_control[1].ToString();
+                                if (Request["idServicio"] != "3") //si no es microbiologia no quiero perder su session "prácticasMicro"
+                                    s_valores += "@prácticasMicro:" + s_control[1].ToString(); 
+                                else
+                                    s_valores = s_valores.Replace(practicasMicro, ""); //si es micro lo borro y lo cargo en GuardarDetalle.
+                                break;
+                        }
+                    }
+                }
+            }
                
             Session["ProtocoloLaboratorio"] = s_valores;
         
         }
 
-        private void GuardarDiagnosticos(Business.Data.Laboratorio.Protocolo oRegistro)
+        private void GuardarDiagnosticos_ant(Business.Data.Laboratorio.Protocolo oRegistro)
         {
             string embarazada = ""; string accion = "Graba";
             //   dtDiagnosticos = (System.Data.DataTable)(Session["Tabla2"]);
@@ -2567,7 +2742,80 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
 
         }
 
-        
+        private void GuardarDiagnosticos(Business.Data.Laboratorio.Protocolo oRegistro)
+        {
+            string embarazada = "";
+            string accion = "Graba";
+
+            // Obtener lista de diagnósticos actuales
+            ISession m_session = NHibernateHttpModule.CurrentSession;
+            ICriteria crit = m_session.CreateCriteria(typeof(ProtocoloDiagnostico));
+            crit.Add(Expression.Eq("IdProtocolo", oRegistro));
+            crit.Add(Expression.Eq("Tipo", "D"));
+            IList detalleActual = crit.List();
+
+            // Crear lista de IDs de los diagnósticos nuevos
+            List<int> listaNueva = new List<int>();
+            for (int i = 0; i < lstDiagnosticosFinal.Items.Count; i++)
+            {
+                listaNueva.Add(int.Parse(lstDiagnosticosFinal.Items[i].Value));
+            }
+
+            // Comparar si hay cambios
+            bool hayCambios = false;
+
+            if (detalleActual.Count != listaNueva.Count)
+                hayCambios = true;
+            else
+            {
+                foreach (ProtocoloDiagnostico oDetalle in detalleActual)
+                {
+                    if (!listaNueva.Contains(oDetalle.IdDiagnostico))
+                    {
+                        hayCambios = true;
+                        break;
+                    }
+                }
+            }
+
+            if (hayCambios)
+            {
+                // Eliminar diagnósticos antiguos
+                foreach (ProtocoloDiagnostico oDetalle in detalleActual)
+                {
+                    oDetalle.Delete();
+                }
+                accion = "Cambia";
+
+                // Guardar los nuevos diagnósticos
+                string listaDx = "";
+                for (int i = 0; i < lstDiagnosticosFinal.Items.Count; i++)
+                {
+                    ProtocoloDiagnostico oDetalle = new ProtocoloDiagnostico();
+                    oDetalle.IdProtocolo = oRegistro;
+                    oDetalle.IdEfector = oRegistro.IdEfector;
+                    oDetalle.IdDiagnostico = int.Parse(lstDiagnosticosFinal.Items[i].Value);
+                    oDetalle.Tipo = "D";
+                    oDetalle.Save();
+
+                    string s_diag = lstDiagnosticosFinal.Items[i].Text;
+                    oDetalle.IdProtocolo.GrabarAuditoriaDetalleProtocolo(
+                        accion, int.Parse(Session["idUsuario"].ToString()), "Diagnóstico", s_diag);
+
+                    embarazada = oDetalle.EsEmbarazada();
+
+                    listaDx = listaDx == "" ? lstDiagnosticosFinal.Items[i].Value : listaDx + ";" + lstDiagnosticosFinal.Items[i].Value;
+                }
+
+                if (embarazada == "E")
+                {
+                    oRegistro.Embarazada = "S";
+                    oRegistro.Save();
+                }
+
+                Session["Dx"] = listaDx;
+            }
+        }
 
         private void GuardarDetalle(Business.Data.Laboratorio.Protocolo oRegistro)
         {         
@@ -2679,8 +2927,6 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
                     { /// si cambió la marca de sin muetsra
                         foreach (DetalleProtocolo oDetalle in listadetalle)
                         {
-                            
-
                             if (trajomuestra == "true") /// es no trajo
                             {
                                 if (oDetalle.TrajoMuestra == "Si") // estaba grabado Si
@@ -2743,7 +2989,17 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
             if (Request["Operacion"].ToString() != "Modifica")
             {
                 if (chkRecordarPractica.Checked)
-                    Session["ProtocoloLaboratorio"] += "@prácticas:" + recordar_practicas;
+                {
+                    //actualizo los analisis a recordar por IdTipoServicio
+                    switch (oRegistro.IdTipoServicio.IdTipoServicio)
+                    {
+                        case 1:  Session["ProtocoloLaboratorio"] += "@prácticas:" + recordar_practicas; /*labo general*/ break;
+                        case 3:  Session["ProtocoloLaboratorio"] += "@prácticasMicro:" + recordar_practicas;  /*microbiologia*/ break;
+                    }
+
+                   
+
+                }
             }
 
 
@@ -3090,11 +3346,6 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
 
   
 
-        protected void txtCodigo_TextChanged(object sender, EventArgs e)
-        {
-           
-        }
-
         protected void ddlItem_SelectedIndexChanged(object sender, EventArgs e)
         {
             ///////Con la selección del item se muestra el codigo
@@ -3180,11 +3431,6 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
 
 
        
-
-        protected void txtCodigo_TextChanged1(object sender, EventArgs e)
-        {
-         
-        }
 
         protected void btnCancelar_Click(object sender, EventArgs e)
         {
@@ -3476,7 +3722,10 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
             //BuscarCodigoDiagnostico();
              
         }
-
+        private bool ExisteItem(ListControl lista, string value)
+        {
+            return lista.Items.FindByValue(value) != null;
+        }
 
         private void BuscarCodigoDiagnostico()
         {
@@ -3488,7 +3737,7 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
 
                 if (oC.NomencladorDiagnostico == 0) /// Cie10
                 {
-                    string m_strSQL = @"select id, codigo + ' -' + nombre from sys_cie10 with (nolock) where CODIGO like '%" + txtCodigoDiagnostico.Text.Trim() + "%'";
+                    string m_strSQL = @"select id, codigo + ' -' + nombre from sys_cie10 with (nolock) where tipo='DIAG' and CODIGO like '%" + txtCodigoDiagnostico.Text.Trim() + "%'";
 
                     DataSet Ds = new DataSet();
                     SqlConnection conn = new SqlConnection(ConfigurationManager.ConnectionStrings["SIL_ReadOnly"].ConnectionString); ///Performance: conexion de solo lectura
@@ -3507,18 +3756,20 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
 
                         if (cantDiag == 1) //Si encuentra por codigo un unico diagnsotico se pasa automatico a diagnostico del paciente para evitar mas clic: sug. H. Plottier
                         {
-                            lstDiagnosticosFinal.Items.Clear();
-                            lstDiagnosticosFinal.Items.Add(oDia);
-                            lstDiagnosticosFinal.UpdateAfterCallBack = true;
+                            //    lstDiagnosticosFinal.Items.Clear();
+                            if (!ExisteItem(lstDiagnosticosFinal, oDia.Value))
+                            {
+                                lstDiagnosticosFinal.Items.Add(oDia);
+                                lstDiagnosticosFinal.UpdateAfterCallBack = true;
+                            }
+
+
                         }
                     }
 
 
-                     
-                       
 
-                     
-                    
+
                 }
                 else /// diagnostico propio
                 {
@@ -3618,7 +3869,7 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
                     //}
 
 
-                    string m_strSQL = @"select id, codigo + ' -' + nombre from sys_cie10 (nolock) where Nombre like '%" + txtNombreDiagnostico.Text.Trim() + "%' order by Nombre";
+                    string m_strSQL = @"select id, codigo + ' -' + nombre from sys_cie10 (nolock) where  tipo='DIAG' and  Nombre like '%" + txtNombreDiagnostico.Text.Trim() + "%' order by Nombre";
 
                     DataSet Ds = new DataSet();
                     SqlConnection conn = new SqlConnection(ConfigurationManager.ConnectionStrings["SIL_ReadOnly"].ConnectionString); ///Performance: conexion de solo lectura
@@ -3784,7 +4035,7 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
 
             ///
 
-            if ((TxtDatos.Value == "") || (TxtDatos.Value == "1###on@"))
+                if ((TxtDatos.Value == "") || (TxtDatos.Value == "1###on@") || (TxtDatos.Value == "1###on#0@") || TxtDatos.Value == "1###false#0@")
                 {
 
                     args.IsValid = false;
@@ -4570,7 +4821,8 @@ where pd.idProtocolo=" + oRegistro.IdProtocolo.ToString();
             string m_ssql = @"SELECT top 20 ID, Codigo + ' - ' + Nombre as nombre, count (*)  cantidad
 FROM Sys_CIE10 c (nolock)
 inner join LAB_ProtocoloDiagnostico p (nolock) on c.id = p.idDiagnostico
-where p.idEfector=" + oUser.IdEfector.IdEfector.ToString() + @"
+where  c.tipo='DIAG' and 
+p.idEfector=" + oUser.IdEfector.IdEfector.ToString() + @"
 group by id, codigo, nombre
 ORDER BY cantidad desc";
 
@@ -5306,6 +5558,43 @@ System.Net.ServicePointManager.SecurityProtocol =
                 string analisis = oDerivacion.ObtenerItemsPendientes(Request["idLote"].ToString(), oRegistro.IdProtocolo.ToString());
 
                 CargarProtocoloDerivado(oRegistro, analisis);
+            }
+        }
+
+        protected void txtCodigoEnfermedadBase_TextChanged(object sender, EventArgs e)
+        {
+
+            try
+            {
+                Cie10 oRegistro = new Cie10();
+                oRegistro = (Cie10)oRegistro.Get(typeof(Cie10), "Codigo", txtCodigoEnfermedadBase.Text );
+                if (oRegistro != null) ddlEnfermedadBase.SelectedValue = oRegistro.Id.ToString();
+                ddlEnfermedadBase.UpdateAfterCallBack = true;
+            }
+            catch (Exception ex)
+            {
+                string exception = "";
+                //while (ex != null)
+                //{
+                exception = ex.Message + "<br>";
+
+                //}
+            }
+        }
+
+        protected void ddlEnfermedadBase_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            mostrarCodigoEnfermedadBase();
+        }
+
+        private void mostrarCodigoEnfermedadBase()
+        {
+            if ((ddlEnfermedadBase.SelectedValue != "0") && (ddlEnfermedadBase.SelectedValue != ""))
+            {
+                Cie10 oRegistro = new Cie10();
+                oRegistro = (Cie10)oRegistro.Get(typeof(Cie10), int.Parse(ddlEnfermedadBase.SelectedValue.ToString()));
+                if (oRegistro != null) txtCodigoEnfermedadBase.Text = oRegistro.Codigo;
+                txtCodigoEnfermedadBase.UpdateAfterCallBack = true;
             }
         }
     }

--- a/WebLab/Protocolos/ProtocoloEdit2.aspx.designer.cs
+++ b/WebLab/Protocolos/ProtocoloEdit2.aspx.designer.cs
@@ -7,13 +7,11 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace WebLab.Protocolos
-{
-
-
-    public partial class ProtocoloEdit2
-    {
-
+namespace WebLab.Protocolos {
+    
+    
+    public partial class ProtocoloEdit2 {
+        
         /// <summary>
         /// pnlLista control.
         /// </summary>
@@ -22,7 +20,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl pnlLista;
-
+        
         /// <summary>
         /// gvLista control.
         /// </summary>
@@ -31,7 +29,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.GridView gvLista;
-
+        
         /// <summary>
         /// lblServicio control.
         /// </summary>
@@ -40,7 +38,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblServicio;
-
+        
         /// <summary>
         /// pnlNavegacion control.
         /// </summary>
@@ -49,7 +47,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Panel pnlNavegacion;
-
+        
         /// <summary>
         /// lblEstado control.
         /// </summary>
@@ -58,7 +56,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblEstado;
-
+        
         /// <summary>
         /// lnkAnterior control.
         /// </summary>
@@ -67,7 +65,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.LinkButton lnkAnterior;
-
+        
         /// <summary>
         /// lnkSiguiente control.
         /// </summary>
@@ -76,7 +74,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.LinkButton lnkSiguiente;
-
+        
         /// <summary>
         /// pnlTitulo control.
         /// </summary>
@@ -85,7 +83,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl pnlTitulo;
-
+        
         /// <summary>
         /// pnlPaciente control.
         /// </summary>
@@ -94,7 +92,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Panel pnlPaciente;
-
+        
         /// <summary>
         /// logoRenaper control.
         /// </summary>
@@ -103,7 +101,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlImage logoRenaper;
-
+        
         /// <summary>
         /// lblPaciente control.
         /// </summary>
@@ -112,7 +110,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblPaciente;
-
+        
         /// <summary>
         /// HFIdPaciente control.
         /// </summary>
@@ -121,7 +119,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.HiddenField HFIdPaciente;
-
+        
         /// <summary>
         /// HFNumeroDocumento control.
         /// </summary>
@@ -130,7 +128,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.HiddenField HFNumeroDocumento;
-
+        
         /// <summary>
         /// HFSexo control.
         /// </summary>
@@ -139,7 +137,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.HiddenField HFSexo;
-
+        
         /// <summary>
         /// HFSelMedico control.
         /// </summary>
@@ -148,7 +146,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.HiddenField HFSelMedico;
-
+        
         /// <summary>
         /// HFSelRenaper control.
         /// </summary>
@@ -157,7 +155,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.HiddenField HFSelRenaper;
-
+        
         /// <summary>
         /// HFModificarPaciente control.
         /// </summary>
@@ -166,7 +164,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.HiddenField HFModificarPaciente;
-
+        
         /// <summary>
         /// hplModificarPaciente control.
         /// </summary>
@@ -175,7 +173,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.HyperLink hplModificarPaciente;
-
+        
         /// <summary>
         /// hplActualizarPaciente control.
         /// </summary>
@@ -184,7 +182,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.HyperLink hplActualizarPaciente;
-
+        
         /// <summary>
         /// lblAlertaProtocolo control.
         /// </summary>
@@ -193,7 +191,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblAlertaProtocolo;
-
+        
         /// <summary>
         /// pnlNumero control.
         /// </summary>
@@ -202,7 +200,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Panel pnlNumero;
-
+        
         /// <summary>
         /// lblTitulo control.
         /// </summary>
@@ -211,7 +209,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblTitulo;
-
+        
         /// <summary>
         /// lblUsuario control.
         /// </summary>
@@ -220,7 +218,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblUsuario;
-
+        
         /// <summary>
         /// btnNotificarSISA control.
         /// </summary>
@@ -229,7 +227,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Button btnNotificarSISA;
-
+        
         /// <summary>
         /// lblNroSISA control.
         /// </summary>
@@ -238,7 +236,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblNroSISA;
-
+        
         /// <summary>
         /// spanadjunto control.
         /// </summary>
@@ -247,7 +245,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl spanadjunto;
-
+        
         /// <summary>
         /// lblAdjunto control.
         /// </summary>
@@ -256,7 +254,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblAdjunto;
-
+        
         /// <summary>
         /// lblFechaNacimiento control.
         /// </summary>
@@ -265,7 +263,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblFechaNacimiento;
-
+        
         /// <summary>
         /// lblEdad control.
         /// </summary>
@@ -274,7 +272,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblEdad;
-
+        
         /// <summary>
         /// lblUnidadEdad control.
         /// </summary>
@@ -283,7 +281,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblUnidadEdad;
-
+        
         /// <summary>
         /// lblSexo control.
         /// </summary>
@@ -292,7 +290,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblSexo;
-
+        
         /// <summary>
         /// lnkValidarRenaper control.
         /// </summary>
@@ -301,7 +299,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.LinkButton lnkValidarRenaper;
-
+        
         /// <summary>
         /// lblObraSocial control.
         /// </summary>
@@ -310,7 +308,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblObraSocial;
-
+        
         /// <summary>
         /// btnSelObraSocial control.
         /// </summary>
@@ -319,7 +317,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.LinkButton btnSelObraSocial;
-
+        
         /// <summary>
         /// lblAlertaObraSocial control.
         /// </summary>
@@ -328,7 +326,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.Label lblAlertaObraSocial;
-
+        
         /// <summary>
         /// txtTelefono control.
         /// </summary>
@@ -337,7 +335,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtTelefono;
-
+        
         /// <summary>
         /// cvValidacionInput control.
         /// </summary>
@@ -346,7 +344,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator cvValidacionInput;
-
+        
         /// <summary>
         /// lblIdPaciente control.
         /// </summary>
@@ -355,7 +353,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblIdPaciente;
-
+        
         /// <summary>
         /// txtFecha control.
         /// </summary>
@@ -364,7 +362,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputText txtFecha;
-
+        
         /// <summary>
         /// txtFechaOrden control.
         /// </summary>
@@ -373,7 +371,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputText txtFechaOrden;
-
+        
         /// <summary>
         /// txtFechaTomaMuestra control.
         /// </summary>
@@ -382,7 +380,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputText txtFechaTomaMuestra;
-
+        
         /// <summary>
         /// txtNumeroOrigen control.
         /// </summary>
@@ -391,7 +389,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtNumeroOrigen;
-
+        
         /// <summary>
         /// ddlEfector control.
         /// </summary>
@@ -400,7 +398,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.DropDownList ddlEfector;
-
+        
         /// <summary>
         /// txtEspecialista control.
         /// </summary>
@@ -409,7 +407,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.TextBox txtEspecialista;
-
+        
         /// <summary>
         /// ddlEspecialista control.
         /// </summary>
@@ -418,7 +416,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.DropDownList ddlEspecialista;
-
+        
         /// <summary>
         /// LinkButton1 control.
         /// </summary>
@@ -427,7 +425,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.LinkButton LinkButton1;
-
+        
         /// <summary>
         /// ddlOrigen control.
         /// </summary>
@@ -436,7 +434,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.DropDownList ddlOrigen;
-
+        
         /// <summary>
         /// ddlSectorServicio control.
         /// </summary>
@@ -445,7 +443,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.DropDownList ddlSectorServicio;
-
+        
         /// <summary>
         /// ddlPrioridad control.
         /// </summary>
@@ -454,7 +452,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.DropDownList ddlPrioridad;
-
+        
         /// <summary>
         /// lblSalaCama control.
         /// </summary>
@@ -463,7 +461,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblSalaCama;
-
+        
         /// <summary>
         /// txtSala control.
         /// </summary>
@@ -472,7 +470,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtSala;
-
+        
         /// <summary>
         /// txtCama control.
         /// </summary>
@@ -481,7 +479,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtCama;
-
+        
         /// <summary>
         /// pnlMuestra control.
         /// </summary>
@@ -490,7 +488,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Panel pnlMuestra;
-
+        
         /// <summary>
         /// txtCodigoMuestra control.
         /// </summary>
@@ -499,7 +497,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.TextBox txtCodigoMuestra;
-
+        
         /// <summary>
         /// ddlMuestra control.
         /// </summary>
@@ -508,7 +506,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.DropDownList ddlMuestra;
-
+        
         /// <summary>
         /// lblCaracterSisa control.
         /// </summary>
@@ -517,7 +515,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl lblCaracterSisa;
-
+        
         /// <summary>
         /// ddlCaracter control.
         /// </summary>
@@ -526,7 +524,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.DropDownList ddlCaracter;
-
+        
         /// <summary>
         /// lblNroHisopado control.
         /// </summary>
@@ -535,7 +533,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl lblNroHisopado;
-
+        
         /// <summary>
         /// txtNumeroOrigen2 control.
         /// </summary>
@@ -544,7 +542,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtNumeroOrigen2;
-
+        
         /// <summary>
         /// lblErrorMedico control.
         /// </summary>
@@ -553,7 +551,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.Label lblErrorMedico;
-
+        
         /// <summary>
         /// diag control.
         /// </summary>
@@ -562,7 +560,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlImage diag;
-
+        
         /// <summary>
         /// tab3Titulo control.
         /// </summary>
@@ -571,7 +569,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl tab3Titulo;
-
+        
         /// <summary>
         /// tituloCalidad control.
         /// </summary>
@@ -580,7 +578,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl tituloCalidad;
-
+        
         /// <summary>
         /// inci control.
         /// </summary>
@@ -589,7 +587,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlImage inci;
-
+        
         /// <summary>
         /// tableTitulo control.
         /// </summary>
@@ -598,7 +596,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlTable tableTitulo;
-
+        
         /// <summary>
         /// TxtCantidadFilas control.
         /// </summary>
@@ -607,7 +605,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputHidden TxtCantidadFilas;
-
+        
         /// <summary>
         /// CodOS control.
         /// </summary>
@@ -616,7 +614,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputHidden CodOS;
-
+        
         /// <summary>
         /// chkRecordarPractica control.
         /// </summary>
@@ -625,7 +623,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CheckBox chkRecordarPractica;
-
+        
         /// <summary>
         /// ddlRutina control.
         /// </summary>
@@ -634,7 +632,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.DropDownList ddlRutina;
-
+        
         /// <summary>
         /// lnkAgregarRutina control.
         /// </summary>
@@ -643,7 +641,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.LinkButton lnkAgregarRutina;
-
+        
         /// <summary>
         /// ddlItem control.
         /// </summary>
@@ -652,7 +650,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.DropDownList ddlItem;
-
+        
         /// <summary>
         /// lnkAgregarItem control.
         /// </summary>
@@ -661,7 +659,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.LinkButton lnkAgregarItem;
-
+        
         /// <summary>
         /// TxtDatosCargados control.
         /// </summary>
@@ -670,7 +668,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputHidden TxtDatosCargados;
-
+        
         /// <summary>
         /// TxtDatos control.
         /// </summary>
@@ -679,7 +677,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputHidden TxtDatos;
-
+        
         /// <summary>
         /// txtTareas control.
         /// </summary>
@@ -688,7 +686,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputHidden txtTareas;
-
+        
         /// <summary>
         /// txtCodigoDiagnostico control.
         /// </summary>
@@ -697,7 +695,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.TextBox txtCodigoDiagnostico;
-
+        
         /// <summary>
         /// txtNombreDiagnostico control.
         /// </summary>
@@ -706,7 +704,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.TextBox txtNombreDiagnostico;
-
+        
         /// <summary>
         /// btnBusquedaDiagnostico control.
         /// </summary>
@@ -715,7 +713,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.Button btnBusquedaDiagnostico;
-
+        
         /// <summary>
         /// btnBusquedaFrecuente control.
         /// </summary>
@@ -724,7 +722,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.Button btnBusquedaFrecuente;
-
+        
         /// <summary>
         /// btnRecordarDiagnostico control.
         /// </summary>
@@ -733,7 +731,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.Button btnRecordarDiagnostico;
-
+        
         /// <summary>
         /// lstDiagnosticos control.
         /// </summary>
@@ -742,7 +740,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.ListBox lstDiagnosticos;
-
+        
         /// <summary>
         /// lblMensajeDiagnostico control.
         /// </summary>
@@ -751,7 +749,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.Label lblMensajeDiagnostico;
-
+        
         /// <summary>
         /// btnAgregarDiagnostico control.
         /// </summary>
@@ -760,7 +758,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.ImageButton btnAgregarDiagnostico;
-
+        
         /// <summary>
         /// lstDiagnosticosFinal control.
         /// </summary>
@@ -769,7 +767,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.ListBox lstDiagnosticosFinal;
-
+        
         /// <summary>
         /// btnSacarDiagnostico control.
         /// </summary>
@@ -778,7 +776,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.ImageButton btnSacarDiagnostico;
-
+        
         /// <summary>
         /// lblFechaFIS control.
         /// </summary>
@@ -787,7 +785,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.Label lblFechaFIS;
-
+        
         /// <summary>
         /// txtFechaFIS control.
         /// </summary>
@@ -796,7 +794,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputText txtFechaFIS;
-
+        
         /// <summary>
         /// chkSinFIS control.
         /// </summary>
@@ -805,7 +803,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CheckBox chkSinFIS;
-
+        
         /// <summary>
         /// Label1 control.
         /// </summary>
@@ -814,7 +812,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.Label Label1;
-
+        
         /// <summary>
         /// txtFechaFUC control.
         /// </summary>
@@ -823,7 +821,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputText txtFechaFUC;
-
+        
         /// <summary>
         /// chkSinFUC control.
         /// </summary>
@@ -832,7 +830,43 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CheckBox chkSinFUC;
-
+        
+        /// <summary>
+        /// pnlEnfermedadBase control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Panel pnlEnfermedadBase;
+        
+        /// <summary>
+        /// lblEB control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::Anthem.Label lblEB;
+        
+        /// <summary>
+        /// txtCodigoEnfermedadBase control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::Anthem.TextBox txtCodigoEnfermedadBase;
+        
+        /// <summary>
+        /// ddlEnfermedadBase control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::Anthem.DropDownList ddlEnfermedadBase;
+        
         /// <summary>
         /// pnlEtiquetas control.
         /// </summary>
@@ -841,7 +875,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Panel pnlEtiquetas;
-
+        
         /// <summary>
         /// rdbSeleccionarAreasEtiquetas control.
         /// </summary>
@@ -850,7 +884,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.RadioButtonList rdbSeleccionarAreasEtiquetas;
-
+        
         /// <summary>
         /// chkAreaCodigoBarra control.
         /// </summary>
@@ -859,7 +893,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.CheckBoxList chkAreaCodigoBarra;
-
+        
         /// <summary>
         /// ddlImpresora2 control.
         /// </summary>
@@ -868,7 +902,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.DropDownList ddlImpresora2;
-
+        
         /// <summary>
         /// btnReimprimirCodigoBarras control.
         /// </summary>
@@ -877,7 +911,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.Button btnReimprimirCodigoBarras;
-
+        
         /// <summary>
         /// lblMensajeImpresion control.
         /// </summary>
@@ -886,7 +920,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.Label lblMensajeImpresion;
-
+        
         /// <summary>
         /// chkRecordarConfiguracion control.
         /// </summary>
@@ -895,7 +929,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.CheckBox chkRecordarConfiguracion;
-
+        
         /// <summary>
         /// chkCodificaPaciente control.
         /// </summary>
@@ -904,7 +938,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.CheckBox chkCodificaPaciente;
-
+        
         /// <summary>
         /// pnlIncidencia control.
         /// </summary>
@@ -913,7 +947,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Panel pnlIncidencia;
-
+        
         /// <summary>
         /// IncidenciaEdit1 control.
         /// </summary>
@@ -922,7 +956,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::WebLab.Calidad.IncidenciaEdit IncidenciaEdit1;
-
+        
         /// <summary>
         /// pnlImpresoraAlta control.
         /// </summary>
@@ -949,7 +983,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtObservacion;
-
+        
         /// <summary>
         /// chkNotificar control.
         /// </summary>
@@ -958,7 +992,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CheckBox chkNotificar;
-
+        
         /// <summary>
         /// hidToken control.
         /// </summary>
@@ -967,7 +1001,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputHidden hidToken;
-
+        
         /// <summary>
         /// txtCodigo control.
         /// </summary>
@@ -976,7 +1010,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.TextBox txtCodigo;
-
+        
         /// <summary>
         /// txtCodigosRutina control.
         /// </summary>
@@ -985,7 +1019,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::Anthem.TextBox txtCodigosRutina;
-
+        
         /// <summary>
         /// btnCancelar control.
         /// </summary>
@@ -994,7 +1028,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Button btnCancelar;
-
+        
         /// <summary>
         /// btnGuardar control.
         /// </summary>
@@ -1003,7 +1037,7 @@ namespace WebLab.Protocolos
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Button btnGuardar;
-
+        
         /// <summary>
         /// ValidationSummary1 control.
         /// </summary>

--- a/WebLab/Protocolos/ProtocoloList.aspx.cs
+++ b/WebLab/Protocolos/ProtocoloList.aspx.cs
@@ -242,23 +242,7 @@ namespace WebLab.Protocolos
                 m_ssql += " and idTipoServicio>0";
             oUtil.CargarCombo(ddlServicio, m_ssql, "idTipoServicio", "nombre", connReady);
 
-
-
-            //if (oUser.Administrador)
-            //{
-            //    m_ssql = "select distinct E.idEfector, E.nombre  from sys_efector E " +
-            //         " INNER JOIN lab_Configuracion C on C.idEfector=E.idEfector " +
-            //         "order by E.nombre";
-
-            //    oUtil.CargarCombo(ddlEfector, m_ssql, "idEfector", "nombre");
-            //    ddlEfector.Items.Insert(0, new ListItem("Configuracion General", "227"));
-            //}
-            //else
-            //{
-            //    m_ssql = "select  E.idEfector, E.nombre  from sys_efector E  where E.idEfector= " + oUser.IdEfector.IdEfector.ToString();
-            //    oUtil.CargarCombo(ddlEfector, m_ssql, "idEfector", "nombre");
-            //}
-
+             
 
 
 
@@ -314,7 +298,8 @@ namespace WebLab.Protocolos
                 ddlPrioridad.Visible = false;
             }
             ///Carga de Sectores
-            m_ssql = "SELECT idSectorServicio,  nombre  + ' - ' + prefijo as nombre FROM LAB_SectorServicio with (nolock)  WHERE (baja = 0) order by nombre";
+            m_ssql = @"SELECT idSectorServicio,  nombre  + ' - ' + prefijo as nombre FROM LAB_SectorServicio S with (nolock)  WHERE (baja = 0) 
+                  and exists(select 1 from Lab_SectorServicioEfector SE where SE.idSectorServicio = S.idSectorServicio and se.idefector = "+oUser.IdEfector.IdEfector.ToString()+@")  order by nombre";                
             oUtil.CargarCombo(ddlSectorServicio, m_ssql, "idSectorServicio", "nombre", connReady);
             ddlSectorServicio.Items.Insert(0, new ListItem("-- Todos --", "0"));
 

--- a/WebLab/Protocolos/ProtocoloProductoEdit.aspx.cs
+++ b/WebLab/Protocolos/ProtocoloProductoEdit.aspx.cs
@@ -472,11 +472,22 @@ namespace WebLab.Protocolos
             
             
             ///Carga de grupos de numeración solo si el tipo de numeración es 2: por Grupos => obsoleto con sil2
-            string m_ssql = "SELECT  idSectorServicio,  prefijo + ' - ' + nombre   as nombre FROM LAB_SectorServicio with (nolock) WHERE (baja = 0) order by nombre";
+            //string m_ssql = "SELECT  idSectorServicio,  prefijo + ' - ' + nombre   as nombre FROM LAB_SectorServicio with (nolock) WHERE (baja = 0) order by nombre";
+            //oUtil.CargarCombo(ddlSectorServicio, m_ssql, "idSectorServicio", "nombre", connReady);
+            //ddlSectorServicio.Items.Insert(0, new ListItem("Seleccione", "0"));
+
+
+            string str_condicion = ")";
+            if ((Request["Operacion"].ToString() == "Modifica") && (Request["idProtocolo"] != null))
+                str_condicion = "  or exists (select 1 from LAB_Protocolo p WHERE p.idsector  = s.idSectorServicio and idProtocolo = " + Request["idProtocolo"].ToString() + ")) ";
+
+
+            string m_ssql = @"SELECT  s.idSectorServicio,  s.prefijo + ' - ' + s.nombre   as nombre FROM LAB_SectorServicio  S with (nolock) 
+                             WHERE (baja = 0)  
+                             and ( exists (select 1 from Lab_SectorServicioEfector SE where SE.idSectorServicio=S.idSectorServicio and se.idefector=" + oUser.IdEfector.IdEfector.ToString() + @" )" + str_condicion + @" order by nombre";
+
             oUtil.CargarCombo(ddlSectorServicio, m_ssql, "idSectorServicio", "nombre", connReady);
             ddlSectorServicio.Items.Insert(0, new ListItem("Seleccione", "0"));
-
-
             /////////////////////////////////////////////CODIGO DE BARRAS//////////////////////////////////////////////////////////////////////
             tab3Titulo.Visible = false;
             pnlEtiquetas.Visible = false;

--- a/WebLab/Resultados/AnalisisEdit.aspx
+++ b/WebLab/Resultados/AnalisisEdit.aspx
@@ -536,6 +536,8 @@
             OrdenarDatos();
 
             contadorfilas = contadorfilas - 1;
+            document.getElementById('<%= Page.Master.FindControl("ContentPlaceHolder1").FindControl("TxtCantidadFilas").ClientID %>').value = contadorfilas;
+
         }
         else {
 
@@ -571,7 +573,7 @@
                 desde.id = 'Desde_' + pos;
 
                 pos = pos + 1;
-                str = str + nroFila.value + '#' + cod.value + '#' + tarea.value + '#' + desde.value + '@';
+                str = str + nroFila.value + '#' + cod.value + '#' + tarea.value + '#' + desde.checked + '@';
             }
         }
         document.getElementById('<%= Page.Master.FindControl("ContentPlaceHolder1").FindControl("TxtDatos").ClientID %>').value = str;
@@ -635,8 +637,11 @@
                 var boton = document.getElementById('boton_' + con);
 
 
-                if (sItem[2] == 'True')
+                if (sItem[2] == '1')
                     document.getElementById('Codigo_' + con).className = 'codigoConResultado';
+
+                if (sItem[2] == '2')///resultado validado
+                    document.getElementById('Codigo_' + con).className = 'codigoConResultadoValidado';
                 desde.checked = sinMuestra;
 
 
@@ -648,5 +653,5 @@
 
 
 
-</script>
+    </script>
    </asp:Content>

--- a/WebLab/Resultados/AnalisisEdit.aspx
+++ b/WebLab/Resultados/AnalisisEdit.aspx
@@ -536,6 +536,8 @@
             OrdenarDatos();
 
             contadorfilas = contadorfilas - 1;
+            document.getElementById('<%= Page.Master.FindControl("ContentPlaceHolder1").FindControl("TxtCantidadFilas").ClientID %>').value = contadorfilas;
+
         }
         else {
 
@@ -571,7 +573,7 @@
                 desde.id = 'Desde_' + pos;
 
                 pos = pos + 1;
-                str = str + nroFila.value + '#' + cod.value + '#' + tarea.value + '#' + desde.value + '@';
+                str = str + nroFila.value + '#' + cod.value + '#' + tarea.value + '#' + desde.checked + '@';
             }
         }
         document.getElementById('<%= Page.Master.FindControl("ContentPlaceHolder1").FindControl("TxtDatos").ClientID %>').value = str;

--- a/WebLab/Resultados/AnalisisEdit.aspx
+++ b/WebLab/Resultados/AnalisisEdit.aspx
@@ -637,8 +637,11 @@
                 var boton = document.getElementById('boton_' + con);
 
 
-                if (sItem[2] == 'True')
+                if (sItem[2] == '1')
                     document.getElementById('Codigo_' + con).className = 'codigoConResultado';
+
+                if (sItem[2] == '2')///resultado validado
+                    document.getElementById('Codigo_' + con).className = 'codigoConResultadoValidado';
                 desde.checked = sinMuestra;
 
 

--- a/WebLab/Resultados/AnalisisEdit.aspx.cs
+++ b/WebLab/Resultados/AnalisisEdit.aspx.cs
@@ -118,10 +118,19 @@ namespace WebLab.Resultados
                 // Y en la vista del protocolo se ve "duplicado"
                 if (pivote.Add(oDet.IdItem.Nombre)) // Si Add devuelve True es porque lo agrego sin problemas de duplicados
                 {
-                    if (sDatos == "")
-                        sDatos = oDet.IdItem.Codigo + "#" + oDet.TrajoMuestra + "#" + oDet.ConResultado;
+                    string estado = "0";
+                    if ((oDet.IdUsuarioValida > 0) || (oDet.IdUsuarioValidaObservacion > 0)) //validado
+                        estado = "2";
                     else
-                        sDatos += ";" + oDet.IdItem.Codigo + "#" + oDet.TrajoMuestra + "#" + oDet.ConResultado;
+                    {
+                        if ((oDet.IdUsuarioResultado > 0) || (oDet.IdUsuarioObservacion > 0) || (oDet.Enviado == 2)) //cargado
+                            estado = "1";
+                    }
+
+                    if (sDatos == "")
+                        sDatos = oDet.IdItem.Codigo + "#" + oDet.TrajoMuestra + "#" + estado;
+                    else
+                        sDatos += ";" + oDet.IdItem.Codigo + "#" + oDet.TrajoMuestra + "#" + estado;
                     //sDatos += "#" + oDet.IdItem.Codigo + "#" + oDet.IdItem.Nombre + "#" + oDet.TrajoMuestra + "@";                   
                     pivot = oDet.IdItem.Nombre;
                 }
@@ -394,14 +403,12 @@ namespace WebLab.Resultados
                         // GuardarDerivacion(oDetalle);
                         //oDetalle.GuardarDerivacion(oUser);
                     }
-                    else  //si ya esta actualizo si trajo muestra o no //3/3/2026 Y regenero los analisis de las practicas si no estaban en el alta
+                    else  //si ya esta actualizo si trajo muestra o no
                     {
-                        
                         foreach (DetalleProtocolo oDetalle in listadetalle)
                         {
                             if (trajomuestra == "true")
                                 oDetalle.TrajoMuestra = "No";
-
                             else // (trajomuestra == "false"
                             {
                                 /* Bug sobre la edición de determinaciones con la marca “sin muestra”:
@@ -446,10 +453,9 @@ namespace WebLab.Resultados
                                 }
                                 
                             }
-
                             oDetalle.Save();
-                           
                         }
+
                     }
                 }
             }

--- a/WebLab/Resultados/AnalisisEdit.aspx.cs
+++ b/WebLab/Resultados/AnalisisEdit.aspx.cs
@@ -118,10 +118,19 @@ namespace WebLab.Resultados
                 // Y en la vista del protocolo se ve "duplicado"
                 if (pivote.Add(oDet.IdItem.Nombre)) // Si Add devuelve True es porque lo agrego sin problemas de duplicados
                 {
-                    if (sDatos == "")
-                        sDatos = oDet.IdItem.Codigo + "#" + oDet.TrajoMuestra + "#" + oDet.ConResultado;
+                    string estado = "0";
+                    if ((oDet.IdUsuarioValida > 0) || (oDet.IdUsuarioValidaObservacion > 0)) //validado
+                        estado = "2";
                     else
-                        sDatos += ";" + oDet.IdItem.Codigo + "#" + oDet.TrajoMuestra + "#" + oDet.ConResultado;
+                    {
+                        if ((oDet.IdUsuarioResultado > 0) || (oDet.IdUsuarioObservacion > 0) || (oDet.Enviado == 2)) //cargado
+                            estado = "1";
+                    }
+
+                    if (sDatos == "")
+                        sDatos = oDet.IdItem.Codigo + "#" + oDet.TrajoMuestra + "#" + estado;
+                    else
+                        sDatos += ";" + oDet.IdItem.Codigo + "#" + oDet.TrajoMuestra + "#" + estado;
                     //sDatos += "#" + oDet.IdItem.Codigo + "#" + oDet.IdItem.Nombre + "#" + oDet.TrajoMuestra + "@";                   
                     pivot = oDet.IdItem.Nombre;
                 }

--- a/WebLab/Resultados/AnalisisEdit.aspx.designer.cs
+++ b/WebLab/Resultados/AnalisisEdit.aspx.designer.cs
@@ -7,13 +7,11 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace WebLab.Resultados
-{
-
-
-    public partial class AnalisisEdit
-    {
-
+namespace WebLab.Resultados {
+    
+    
+    public partial class AnalisisEdit {
+        
         /// <summary>
         /// hidToken control.
         /// </summary>
@@ -22,7 +20,7 @@ namespace WebLab.Resultados
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlInputHidden hidToken;
-
+        
         /// <summary>
         /// lblProtocolo control.
         /// </summary>
@@ -31,124 +29,7 @@ namespace WebLab.Resultados
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblProtocolo;
-
-        /// <summary>
-        /// cvValidacionInput control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.WebControls.CustomValidator cvValidacionInput;
-
-        /// <summary>
-        /// pnlMuestra control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.WebControls.Panel pnlMuestra;
-
-        /// <summary>
-        /// txtCodigoMuestra control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::Anthem.TextBox txtCodigoMuestra;
-
-        /// <summary>
-        /// ddlMuestra control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::Anthem.DropDownList ddlMuestra;
-
-        /// <summary>
-        /// rvMuestra control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::Anthem.RangeValidator rvMuestra;
-
-        /// <summary>
-        /// TxtCantidadFilas control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.HtmlControls.HtmlInputHidden TxtCantidadFilas;
-
-        /// <summary>
-        /// ddlRutina control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::Anthem.DropDownList ddlRutina;
-
-        /// <summary>
-        /// ddlItem control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::Anthem.DropDownList ddlItem;
-
-        /// <summary>
-        /// TxtDatosCargados control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.HtmlControls.HtmlInputHidden TxtDatosCargados;
-
-        /// <summary>
-        /// TxtDatos control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.HtmlControls.HtmlInputHidden TxtDatos;
-
-        /// <summary>
-        /// txtTareas control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.HtmlControls.HtmlInputHidden txtTareas;
-
-        /// <summary>
-        /// txtCodigo control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::Anthem.TextBox txtCodigo;
-
-        /// <summary>
-        /// txtCodigosRutina control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::Anthem.TextBox txtCodigosRutina;
-
+        
         /// <summary>
         /// ValidationSummary1 control.
         /// </summary>
@@ -157,7 +38,124 @@ namespace WebLab.Resultados
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ValidationSummary ValidationSummary1;
-
+        
+        /// <summary>
+        /// pnlMuestra control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Panel pnlMuestra;
+        
+        /// <summary>
+        /// txtCodigoMuestra control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::Anthem.TextBox txtCodigoMuestra;
+        
+        /// <summary>
+        /// ddlMuestra control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::Anthem.DropDownList ddlMuestra;
+        
+        /// <summary>
+        /// rvMuestra control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::Anthem.RangeValidator rvMuestra;
+        
+        /// <summary>
+        /// TxtCantidadFilas control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlInputHidden TxtCantidadFilas;
+        
+        /// <summary>
+        /// cvValidacionInput control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.CustomValidator cvValidacionInput;
+        
+        /// <summary>
+        /// ddlRutina control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::Anthem.DropDownList ddlRutina;
+        
+        /// <summary>
+        /// ddlItem control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::Anthem.DropDownList ddlItem;
+        
+        /// <summary>
+        /// TxtDatosCargados control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlInputHidden TxtDatosCargados;
+        
+        /// <summary>
+        /// TxtDatos control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlInputHidden TxtDatos;
+        
+        /// <summary>
+        /// txtTareas control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlInputHidden txtTareas;
+        
+        /// <summary>
+        /// txtCodigo control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::Anthem.TextBox txtCodigo;
+        
+        /// <summary>
+        /// txtCodigosRutina control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::Anthem.TextBox txtCodigosRutina;
+        
         /// <summary>
         /// btnGuardar control.
         /// </summary>

--- a/WebLab/Resultados/PredefinidoSelect.aspx.cs
+++ b/WebLab/Resultados/PredefinidoSelect.aspx.cs
@@ -178,7 +178,7 @@ namespace WebLab.Resultados
                 if (chk1.Items[i].Selected)
                 {
                     if (val == "") val = chk1.Items[i].Text;
-                    else val += "\n" + chk1.Items[i].Text;//salto de linea
+                    else val += Environment.NewLine + chk1.Items[i].Text;//salto de linea
                 }
             }
             txtObservacionAnalisis.Text = val;

--- a/WebLab/Resultados/ResultadoBusqueda.aspx.cs
+++ b/WebLab/Resultados/ResultadoBusqueda.aspx.cs
@@ -528,7 +528,8 @@ namespace WebLab.Resultados
             lblServicio.Text = ddlServicio.SelectedItem.Text;
 
             ///Carga de Sectores          
-            m_ssql = "SELECT idSectorServicio, prefijo + ' - ' + nombre as nombre  FROM LAB_SectorServicio (nolock) WHERE (baja = 0) order by nombre";            
+            m_ssql = @"SELECT idSectorServicio, prefijo + ' - ' + nombre as nombre  FROM LAB_SectorServicio S with (nolock) WHERE (baja = 0) 
+                          and exists(select 1 from Lab_SectorServicioEfector SE where SE.idSectorServicio = S.idSectorServicio and se.idefector = "+oUser.IdEfector.IdEfector.ToString()+@")  order by nombre";                            
             oUtil.CargarListBox(lstSector, m_ssql, "idSectorServicio", "nombre");
             for (int i = 0; i < lstSector.Items.Count; i++)
             {

--- a/WebLab/Resultados/ResultadoEdit2.aspx
+++ b/WebLab/Resultados/ResultadoEdit2.aspx
@@ -645,8 +645,7 @@
                                 onclick="btnValidarPendiente_Click" Visible="false" ValidationGroup="0" Width="150px" TabIndex="600" />  
 
                                  &nbsp; 
-           <asp:LinkButton ID="imgPdf" runat="server" CssClass="btn btn-info" ForeColor="White" Text="Buscar" OnClick="imgPdf_Click" Width="140px" >
-                                             <span class="glyphicon glyphicon-download-alt"></span>&nbsp;Descargar PDF</asp:LinkButton>
+           <asp:LinkButton ID="imgPdf" runat="server" CssClass="btn btn-info" ForeColor="White" Text="Buscar" OnClick="imgPdf_Click" Width="140px" Visible="False" ></asp:LinkButton>
 
            <asp:LinkButton ID="imgAdjunto" runat="server" CssClass="btn btn-info" Text="Adjuntar Archivos" ForeColor="White" Width="165px" 
                OnClientClick="AdjuntoProtocoloEdit(); return false;"  Visible="False"></asp:LinkButton>

--- a/WebLab/Resultados/ResultadoEdit2.aspx.cs
+++ b/WebLab/Resultados/ResultadoEdit2.aspx.cs
@@ -728,10 +728,8 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
 
             lblServicio.Text = oRegistro.IdTipoServicio.Nombre.ToUpper();
             //if (Request["Operacion"].ToString() == "HC") { oRegistro.GrabarAuditoriaProtocolo("Consulta", int.Parse(Session["idUsuario"].ToString())); }
-            if (oRegistro.tieneAdjuntoProtocolo())
-            {   spanadjunto.Visible = true; }
-            else
-            {   spanadjunto.Visible = false; }
+            
+            spanadjunto.Visible = oRegistro.tieneAdjuntoProtocolo();
             if (Request["Operacion"].ToString() == "Valida") imgAdjunto.Visible = true;
 
             HFIdProtocolo.Value = CurrentPageIndex.ToString();
@@ -804,7 +802,10 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                     else chkWhonet.Checked = false;
                 }
 
-                lblPlaca.Text = s_placa;
+                if (oRegistro.IdTipoServicio.IdTipoServicio == 3)
+                    lblPlaca.Text = s_placa;
+                else
+                    lblPlaca.Visible = false;
                 CargarListasAislamientos();
                 CargarListaAntibiotico();
                 CargarListasAntibiogramas();
@@ -826,18 +827,19 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                     if (oConserva!=null)
                     lblConservacion.Text = oConserva.Descripcion;
                 }
-                if (oRegistro.IdCaracter > 0)
+                if (oRegistro.IdCaracter > 0)//Caracter se usa para clasificacion SNVS
                 {
                     lblCovid.Visible = true;
                     Caracter oCaracter = new Caracter();
                     oCaracter = (Caracter)oCaracter.Get(typeof(Caracter), oRegistro.IdCaracter);
-                    if (oCaracter!= null)
-                    lblCovid.Text = "Clasificación Covid-19: " + oCaracter.Nombre;
-                    if (oRegistro.FechaInicioSintomas.Year != 1900)
-                        lblCovid.Text = lblCovid.Text + " - FIS: " + oRegistro.FechaInicioSintomas.ToShortDateString();
-                    if (oRegistro.FechaUltimoContacto.Year != 1900)
-                        lblCovid.Text = lblCovid.Text + " - FUC: " + oRegistro.FechaUltimoContacto.ToShortDateString();
+                    if (oCaracter!= null) 
+                    lblCovid.Text = "Clasificación SNVS: " + oCaracter.Nombre;
+                   
                 }
+                if (oRegistro.FechaInicioSintomas.Year != 1900)
+                    lblCovid.Text = lblCovid.Text + " - FIS: " + oRegistro.FechaInicioSintomas.ToShortDateString();
+                if (oRegistro.FechaUltimoContacto.Year != 1900)
+                    lblCovid.Text = lblCovid.Text + " - FUC: " + oRegistro.FechaUltimoContacto.ToShortDateString();
 
                 pnlMicroOrganismo.Visible = true;
                 pnlAntibiograma.Visible = true;
@@ -1021,25 +1023,18 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
             {
                 lblPrioridad.ForeColor = Color.Red;
                 lblPrioridad.Font.Bold = true;
-            }
-
-            //if (oCon.IdSectorDefecto == 0)
-            //{
-               
-            
+            }            
             lblSector.Text = oRegistro.IdSector.Nombre;
             lblSector1.Text = lblSector.Text;
-            //}
+            
             if (oRegistro.Sala != "") lblSector.Text += " Sala: " + oRegistro.Sala;
             if (oRegistro.Cama != "") lblSector.Text += " Cama: " + oRegistro.Cama;
 
             lblDescripcionProducto.Text = oRegistro.DescripcionProducto;
             ///Datos del Paciente            
             if (oRegistro.IdPaciente.IdEstado==2) lblDni.Text = "(Sin DU Temporal)";            
-            else lblDni.Text = oRegistro.IdPaciente.NumeroDocumento.ToString();
-            
-
-            if (oRegistro.IdTipoServicio.IdTipoServicio == 4)
+            else lblDni.Text = oRegistro.IdPaciente.NumeroDocumento.ToString();            
+            if (oRegistro.IdTipoServicio.IdTipoServicio == 4)  //pesquisa neonatal sil1
                 lblPaciente.Text = oRegistro.getDatosParentesco();
             else
                 lblPaciente.Text = oRegistro.IdPaciente.Apellido.ToUpper() + " " + oRegistro.IdPaciente.Nombre.ToUpper();
@@ -1107,11 +1102,8 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
 
                     if (oD.Codigo=="Z32.1") embarazada="E";
                 }
-            }
-
-            //oRegistro.IdPaciente.getCodificaHiv(); //
+            }            
             lblCodigoPaciente.Text = oRegistro.getCodificaHiv(embarazada); //lblSexo.Text.Substring(0, 1) + " " + oRegistro.IdPaciente.Nombre.Substring(0, 2) + oRegistro.IdPaciente.Apellido.Substring(0, 2) + " " + lblFechaNacimiento.Text.Replace("/", "") + embarazada;
-            //lblCodigoPaciente.Text = lblCodigoPaciente.Text.ToUpper();
             
             ///Observaciones de Resultados al pie 
             if (oRegistro.ObservacionResultado != "")
@@ -1124,8 +1116,7 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                 if (oRegistro.ObservacionResultado != "")
                 {
                     txtObservacion.Text = oRegistro.ObservacionResultado;
-                    //pnlObsGeneral.Visible = true;
-                    //btnObservaciones.Enabled = false;
+            
                 }
                 else
                 {
@@ -1136,9 +1127,7 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
             }
           
 
-
-            //if (Request["desde"].ToString() != "Urgencia")
-            //{ 
+            
             if (Request["desde"] != null)
             { 
             if (Request["desde"].ToString() != "Urgencia")
@@ -1150,9 +1139,7 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                     btnActualizarPracticasCarga.Enabled = false;
                 }
             }
-                }
-          
-
+                }          
         }
 
         //private int esdeArea()
@@ -1186,77 +1173,38 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
 
         private void LlenarTabla(string p)
         {
-            //bool hayAntecedente = false;
-            string m_strSQL = " 1=1 ";
-                
-         
-                              
-
-            if (Request["idArea"].ToString() != "0")   m_strSQL += " and idArea in (" + Request["idArea"].ToString()+")";
-
-
-            //////////////////control de hemoterapia            
-            //if (Request["desde"] != null)
-            //{
-            //    if (Request["desde"].ToString() != "Urgencia")
-            //    { if (esHemoterapia()) m_strSQL += " and idItem in (select iditem from lab_item where codigo like '433%')"; }
-            //}
-            ////////////////////
-
+           
+            string m_strSQL = " 1=1 ";                                                       
+            if (Request["idArea"].ToString() != "0")   m_strSQL += " and idArea in (" + Request["idArea"].ToString()+")";            
             if (Request["Operacion"].ToString() == "HC")
             {
                 if (Request["validado"].ToString() == "1") { m_strSQL += " and estado=2 "; }
-                m_strSQL += " order by ordenArea, orden, idDetalleProtocolo ";  //orden de impresion
-
-             
-
+                m_strSQL += " order by ordenArea, orden, idDetalleProtocolo ";  //orden de impresion             
             }
             else
             { 
                 if (oCon.OrdenCargaResultado)/// orden de impresion
                     m_strSQL += " order by ordenArea, orden, idDetalleProtocolo ";  //orden de impresion
                 else
-                    m_strSQL += " order by  idDetalleProtocolo ";  //orden de impresion
-                
-            }
-
-             
-
-            /*nuevo con SP*/
-
+                    m_strSQL += " order by  idDetalleProtocolo ";  //orden de impresion                
+            }                         
             DataSet Ds = new DataSet();
             SqlConnection conn = (SqlConnection)NHibernateHttpModule.CurrentSession.Connection;
             SqlCommand cmd = new SqlCommand();
-            cmd.CommandType = CommandType.StoredProcedure;
-             
-                cmd.CommandText = "[LAB_Resultados]";
-
-
+            cmd.CommandType = CommandType.StoredProcedure;             
+            cmd.CommandText = "[LAB_Resultados]";
             cmd.Parameters.Add("@idProtocolo", SqlDbType.Int);
             cmd.Parameters["@idProtocolo"].Value = int.Parse(p);
-
-
             cmd.Parameters.Add("@FiltroBusqueda", SqlDbType.NVarChar);
-            cmd.Parameters["@FiltroBusqueda"].Value = m_strSQL;
-             
+            cmd.Parameters["@FiltroBusqueda"].Value = m_strSQL;             
             cmd.Connection = conn;
-
-
             SqlDataAdapter da = new SqlDataAdapter(cmd);
+            da.Fill(Ds);            
 
-            da.Fill(Ds);
-
-            /*fin de nuevo*/
-
-            string s= System.Globalization.CultureInfo.CurrentCulture.NumberFormat.CurrencyDecimalSeparator;
-
-    
+            string s= System.Globalization.CultureInfo.CurrentCulture.NumberFormat.CurrencyDecimalSeparator;    
             string m_titulo= "";
             string m_hijo = "";
-            string m_nombre = "";
- 
-
-
+            string m_nombre = ""; 
             TableRow objFila_TITULO = new TableRow();
             TableCell objCellAnalisis_TITULO = new TableCell();
             TableCell objCellResultado_TITULO = new TableCell();
@@ -1267,38 +1215,28 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
             TableCell objCellPersona_TITULO = new TableCell();
             TableCell objCellObservaciones_TITULO = new TableCell();
             TableCell objCellImagenes_TITULO = new TableCell();
-
-
-
+            
             Label lblAnalisis = new Label();
             lblAnalisis.Text = "ANALISIS";
-            objCellAnalisis_TITULO.Controls.Add(lblAnalisis);
-               
+            objCellAnalisis_TITULO.Controls.Add(lblAnalisis);             
 
             Label lblResultado = new Label();
             lblResultado.Text = "RESULTADO";            
             objCellResultado_TITULO.Controls.Add(lblResultado);
             
-
             Label lblResultadoAnterior = new Label();
             lblResultadoAnterior.Text = "R.ANTER.";
             objCellResultadoAnterior_TITULO.Controls.Add(lblResultadoAnterior);
             
-
             if (Request["Operacion"].ToString() != "HC")
             {
                 Label lblUM = new Label();
                 lblUM.Text = "UM";
                 objCellUnMedida_TITULO.Controls.Add(lblUM);
             }
-
             Label lblVR = new Label();
             lblVR.Text = "VR|METODO";           
-            objCellValoresReferencia_TITULO.Controls.Add(lblVR);
-
-            
-
-
+            objCellValoresReferencia_TITULO.Controls.Add(lblVR);            
             Label lblValida = new Label();
             if ((Request["Operacion"].ToString() == "Carga") || (Request["Operacion"].ToString() == "HC")) lblValida.Text = "";
             else
@@ -1306,98 +1244,61 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                 if (Request["Operacion"].ToString() == "Control") lblValida.Text = "CTRL";
             }
             objCellValida_TITULO.Controls.Add(lblValida);
-
             Label lblCargadoPor = new Label();
-            if ((Request["Operacion"].ToString() == "HC")&&(Request["validado"].ToString() == "1"))
-            {
-                lblCargadoPor.Text = "VALIDADO POR";
-//                Panel1.ScrollBars = ScrollBars.None;
-            }
+            if ((Request["Operacion"].ToString() == "HC")&&(Request["validado"].ToString() == "1"))            
+                lblCargadoPor.Text = "VALIDADO POR";            
             else
-                lblCargadoPor.Text = "ESTADO";
-            
+                lblCargadoPor.Text = "ESTADO";            
             objCellPersona_TITULO.Controls.Add(lblCargadoPor);
-
-
-            /////observaciones
-            //if (Request["Operacion"].ToString() == "Valida")
-            //{
+            
+            
             if (Request["Operacion"].ToString() != "HC")
             {
                 Label lblObservaciones = new Label();
-                lblObservaciones.Text = "OBS.";               
-                //    else
-                //        lblObservaciones.Text = "";
+                lblObservaciones.Text = "OBS.";                           
                 objCellObservaciones_TITULO.Controls.Add(lblObservaciones);
-
                 objCellObservaciones_TITULO.Width = Unit.Pixel(60);
-            }
-            //}             
+            }            
             if (Request["Operacion"].ToString() != "HC")
             {
-                Label lblImagenes = new Label();
-                lblImagenes.Text = "IMG";
-              
+                Label lblImagenes = new Label();                lblImagenes.Text = "IMG";              
                 objCellImagenes_TITULO.Controls.Add(lblImagenes);
                 objCellImagenes_TITULO.Width = Unit.Pixel(60);
-            }
-            //}           
-
+            }            
             objFila_TITULO.Cells.Add(objCellAnalisis_TITULO);
-            objFila_TITULO.Cells.Add(objCellResultado_TITULO);
-
-          
-
+            objFila_TITULO.Cells.Add(objCellResultado_TITULO);          
 
             if ((Request["Operacion"].ToString() == "Valida")||  (Request["Operacion"].ToString() == "Control")) objFila_TITULO.Cells.Add(objCellResultadoAnterior_TITULO);
-
-            if (Request["Operacion"].ToString() != "HC") objFila_TITULO.Cells.Add(objCellUnMedida_TITULO);
-            
+            if (Request["Operacion"].ToString() != "HC") objFila_TITULO.Cells.Add(objCellUnMedida_TITULO);            
             objFila_TITULO.Cells.Add(objCellValoresReferencia_TITULO);
 
             if ((Request["Operacion"].ToString() == "Valida") || (Request["Operacion"].ToString() == "Control"))
-            {
-                //objFila_TITULO.Cells.Add(objCellResultadoAnterior_TITULO);
+            {            
                 objFila_TITULO.Cells.Add(objCellValida_TITULO);
             }
-
-
             objFila_TITULO.Cells.Add(objCellPersona_TITULO);
             objFila_TITULO.Cells.Add(objCellObservaciones_TITULO);
             if (Request["Operacion"].ToString() != "HC") objFila_TITULO.Cells.Add(objCellImagenes_TITULO);
-
-
             objFila_TITULO.CssClass = "myLabelIzquierda";
             objFila_TITULO.BackColor = Color.Gainsboro;
-
-            
             
             Master.FindControl("ContentPlaceHolder1").FindControl("Panel1").Controls.Add(tContenido);
-
             //'añadimos la fila a la tabla
             if (objFila_TITULO != null)   tContenido.Controls.Add(objFila_TITULO);//.Rows.Add(objRow);    
-
-                     
+                                
 
             for (int i = 0; i < Ds.Tables[0].Rows.Count; i++)
-            {  
-                //decimal m_minimoReferencia=-1;
-                //decimal m_maximoReferencia=-1;
-                bool algovalidado = false;
-                
-
+            {              
+                bool algovalidado = false;                
                 string valorReferencia = Ds.Tables[0].Rows[i].ItemArray[11].ToString();
                 int m_idItem = int.Parse(Ds.Tables[0].Rows[i].ItemArray[2].ToString());
                 string unMedida = Ds.Tables[0].Rows[i].ItemArray[8].ToString();
                 string Observaciones = Ds.Tables[0].Rows[i].ItemArray[5].ToString();
                 int tiporesultado = (int.Parse(Ds.Tables[0].Rows[i].ItemArray[7].ToString()));
-                int tipodeterminacion = int.Parse(Ds.Tables[0].Rows[i].ItemArray[6].ToString());
-              
+                int tipodeterminacion = int.Parse(Ds.Tables[0].Rows[i].ItemArray[6].ToString());              
                 int estado = int.Parse(Ds.Tables[0].Rows[i].ItemArray[9].ToString());
                 if (estado == 2) algovalidado = true;
-
-                string m_metodo = Ds.Tables[0].Rows[i].ItemArray[10].ToString();
-           
+                string m_metodo = Ds.Tables[0].Rows[i].ItemArray[10].ToString();           
                 string m_observacionReferencia =Ds.Tables[0].Rows[i].ItemArray[13].ToString();
                 string m_usuarioCarga = Ds.Tables[0].Rows[i].ItemArray[14].ToString();
                 string m_trajoMuestra = Ds.Tables[0].Rows[i].ItemArray[15].ToString();
@@ -1414,15 +1315,12 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                 string m_usuariovalida = Ds.Tables[0].Rows[i].ItemArray[28].ToString();
                 int i_iddetalleProtocolo= int.Parse( Ds.Tables[0].Rows[i].ItemArray[26].ToString());
                 string m_codificaPaciente = Ds.Tables[0].Rows[i].ItemArray[27].ToString();
-
                 string m_estadoObservacion = Ds.Tables[0].Rows[i].ItemArray[29].ToString();
-
                 if (m_codificaPaciente == "True")
                 {
                     lblPaciente.Visible = false;
                     lblCodigoPaciente.Visible = true;
                 }
-
                 m_hijo = Ds.Tables[0].Rows[i].ItemArray[1].ToString();
                 m_titulo = Ds.Tables[0].Rows[i].ItemArray[0].ToString();
                 
@@ -1440,10 +1338,7 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                 objCellUnMedida.Width = Unit.Pixel(60);
                 objCellImagenes.Width = Unit.Pixel(60);
                 objCellObservaciones.Width = Unit.Pixel(60);
-
-                decimal x = 0;
-               
-
+                decimal x = 0;               
                 if ((m_hijo != m_titulo)&& (m_nombre!=m_titulo)) ///poner titulo de la practica
                 {                    
                         TableRow objRow = new TableRow();
@@ -1452,7 +1347,6 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                         lbl0.Text = Ds.Tables[0].Rows[i].ItemArray[0].ToString();
                         lbl0.TabIndex = short.Parse("500");
                         lbl0.Font.Bold = true;
-
                         Master.FindControl("ContentPlaceHolder1").FindControl("Panel1").Controls.Add(lbl0);
                         objCell.Controls.Add(lbl0);
                         if (Request["Operacion"].ToString() == "HC")
@@ -1462,12 +1356,9 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                         
                         objRow.Cells.Add(objCell);                      
                         objRow.CssClass = "myLabelIzquierda";
-                        tContenido.Controls.Add(objRow);
-                      
+                        tContenido.Controls.Add(objRow);                      
                         m_nombre = m_titulo;                                                        
-                }
-                
-                  
+                }                                  
 
                 Label lbl1 = new Label();
                 if (m_hijo == m_titulo) lbl1.Text =m_hijo; 
@@ -1501,8 +1392,7 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                     tContenido.Controls.Add(objRowTitulo);
 
                     /// puede ser tambien derivable el titulo 
-                    //if  (oDetalle.esDerivado()) //(oItem.esDerivado(oCon.IdEfector))
-                    //{
+                    
                         Label lblDerivacion = new Label();
                         lblDerivacion.Font.Italic = true;
                         lblDerivacion.TabIndex = short.Parse("500");
@@ -1511,34 +1401,11 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                         Derivacion oDeriva = new Derivacion();
                         oDeriva = (Derivacion)oDeriva.Get(typeof(Derivacion), "IdDetalleProtocolo", oDetalle);
                         if (oDeriva != null)  /// esta pendiente
-                        {
-                        //    estadoDerivacion = "Pendiente de Derivacion";
-                        //    lblDerivacion.ForeColor = Color.Red;
-                        //}
-                        //else
-                        //{
-                        /* if (oDeriva.Estado == 0) /// pendiente                            
-                         {
-                             estadoDerivacion = "Pendiente de Derivacion";
-                             lblDerivacion.ForeColor = Color.Red;
-                         }
-                         if (oDeriva.Estado == 1) /// enviado
-                             estadoDerivacion = oDetalle.ResultadoCar; //  "Derivado: " + oItem.GetEfectorDerivacion(oCon.IdEfector);
-                         if (oDeriva.Estado == 2) /// no enviado
-                             estadoDerivacion = oDetalle.ResultadoCar; //" No Derivado. " + oDeriva.Observacion;
-
-                         if (oDeriva.Estado == 4) // --> Pendiente de Derivar
-                          {
-                             estadoDerivacion = oDetalle.ResultadoCar;
-                             lblDerivacion.ForeColor = Color.Red;
-                         }
-                        */
+                        {                        
                             estadoDerivacion = oDetalle.ResultadoCar; //Para todos los estados
                             lblDerivacion.Font.Bold = true;
-
                             if (oDeriva.Resultado != "")
-                                estadoDerivacion += " - Resultado Informado: " + oDeriva.Resultado;
-                        //}
+                                estadoDerivacion += " - Resultado Informado: " + oDeriva.Resultado;                        
 
                         lblDerivacion.Text = estadoDerivacion;
                         objCellResultado.ColumnSpan = 1;
@@ -1554,29 +1421,27 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                         //     objCellResultado.ColumnSpan = 5;
                         objCellResultado.Controls.Add(lblSinMuestra);
                     }
-
-
                 }
                 else
                 {
-                    objCellAnalisis.Controls.Add(lbl1);
-
-                     
-
+                    objCellAnalisis.Controls.Add(lbl1);                     
                     if ((oDetalle.IdUsuarioPreValida>0) && (oDetalle.IdUsuarioValida==0))
                             { estado = 2; }
-                    //     string m_idSuperItem = oDetalle.IdItem.IdItem.ToString();
-
-                     
-                  string   s_placaaux = oDetalle.getPlaca();
-                    if (s_placaaux != "")
+                    if (oDetalle.IdProtocolo.IdTipoServicio.IdTipoServicio == 3)
                     {
-                        if (s_placa == "")
-                            s_placa = s_placaaux;
-                        else
-                            s_placa += "-" + s_placaaux;
+                        string s_placaaux = oDetalle.getPlaca();///Caro: ver como evitar recorrer esto cuando solo lo usa un efector
+                        if (s_placaaux != "")
+                        {
+                            // Verificar si ya existe
+                            if (!s_placa.Split('-').Contains(s_placaaux))
+                            {
+                                if (s_placa == "")
+                                    s_placa = s_placaaux;
+                                else
+                                    s_placa += "-" + s_placaaux;
+                            }
+                        }
                     }
-
 
 
                     ///Antes de mostrar el control verifica  si está derivado                    
@@ -1584,7 +1449,7 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                     //   if (oItem.esDerivado(oCon.IdEfector))
                     //if (oDetalle.esDerivado()) //(oItem.esDerivado(oCon.IdEfector))
                     //{
-                        Label lblDerivacion = new Label();
+                    Label lblDerivacion = new Label();
                         lblDerivacion.Font.Italic = true;
                         lblDerivacion.TabIndex = short.Parse("500");
                         //Verifica el estado de la derivacion
@@ -1593,25 +1458,7 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                         oDeriva = (Derivacion)oDeriva.Get(typeof(Derivacion), "IdDetalleProtocolo", oDetalle);
                         if (oDeriva != null)  /// esta pendiente
                         {
-                        //    estadoDerivacion = "Pendiente de Derivacion";
-                        //    lblDerivacion.ForeColor = Color.Red;
-                        //}
-                        //else
-                        //{
-                            /*if (oDeriva.Estado == 0) /// pendiente                            
-                            {
-                                estadoDerivacion = oDetalle.ResultadoCar; //"Pendiente de Derivacion";
-                                lblDerivacion.ForeColor = Color.Red;
-                            }
-                            if (oDeriva.Estado == 1) /// enviado
-                                estadoDerivacion = oDetalle.ResultadoCar; //"Derivado: " + oItem.GetEfectorDerivacion(oCon.IdEfector);
-                            if (oDeriva.Estado == 2) /// no enviado
-                                estadoDerivacion = oDetalle.ResultadoCar; // " No Derivado. " + oDeriva.Observacion;
-                            if (oDeriva.Estado == 4) // --> Pendiente de Derivar
-                            {
-                                estadoDerivacion = oDetalle.ResultadoCar;
-                                lblDerivacion.ForeColor = Color.Red;
-                            }*/
+                       
                             estadoDerivacion = oDetalle.ResultadoCar; //Para todos los estados
                             lblDerivacion.Font.Bold = true;
 
@@ -1632,8 +1479,7 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                             lblSinMuestra.TabIndex = short.Parse("500");
                             lblSinMuestra.Text = "Sin Muestra";// +oItem.IdEfectorDerivacion.Nombre; /// Ds.Tables[0].Rows[i].ItemArray[1].ToString();
                             lblSinMuestra.Font.Italic = true;
-                            lblSinMuestra.ForeColor = Color.Blue;
-                            //     objCellResultado.ColumnSpan = 5;
+                            lblSinMuestra.ForeColor = Color.Blue;                            
                             objCellResultado.Controls.Add(lblSinMuestra);
                         }
                         else
@@ -1642,15 +1488,11 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                             { string s_determinacion = oDetalle.IdSubItem.IdItem.ToString();
                                 string s_idPaciente = oDetalle.IdProtocolo.IdPaciente.IdPaciente.ToString();
                                 switch (tiporesultado)//tipoResultado
-                                {
-                                
-
-
+                                {                                
                                     case 4://Checklistbox
                                         {
                                             if (Request["Operacion"].ToString() != "HC")
-                                            {
-                                                ///   Verifica si la determinacion tiene una lista predeterminada de resultados
+                                            {                                                ///   Verifica si la determinacion tiene una lista predeterminada de resultados
                                                 ISession m_session = NHibernateHttpModule.CurrentSession;
                                                 ICriteria crit = m_session.CreateCriteria(typeof(ResultadoItem));
                                                 crit.Add(Expression.Eq("IdItem", oItem));
@@ -1670,7 +1512,6 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                     chk1.ID = "c" + m_idItem.ToString();
                                                     //chk1.ID = "c" + m_idSuperItem +";"+m_idItem.ToString(); 
                                                     chk1.TabIndex = short.Parse(i + 1.ToString());
-
                                                     foreach (ResultadoItem oResultado in resultados)
                                                     {
                                                         ListItem Item = new ListItem();
@@ -1680,20 +1521,12 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                         if (oResultado.ResultadoDefecto)
                                                             m_resultadoDefecto = oResultado.Resultado;
                                                     }
-
                                                     chk1.AutoPostBack = true;
-                                                    chk1.SelectedIndexChanged += new EventHandler(chk1_SelectedIndexChanged);
-
-                                                     
+                                                    chk1.SelectedIndexChanged += new EventHandler(chk1_SelectedIndexChanged);                                                     
                                                     chk1.CssClass = "myList";
-
-
-                                                    Anthem.TextBox txt1 = new Anthem.TextBox();
-                                                    //TextBox txt1 = new TextBox();
-
+                                                    Anthem.TextBox txt1 = new Anthem.TextBox();                                                    
                                                     txt1.ID = m_idItem.ToString();
-                                                    txt1.ReadOnly = true;// no es posible editar como texto, sino que agregar /quitar desde las opciones
-                                                    //txt1.ID =m_idSuperItem +";"+ m_idItem.ToString();
+                                                    txt1.ReadOnly = true;// no es posible editar como texto, sino que agregar /quitar desde las opciones                                                    
                                                     txt1.TabIndex = short.Parse(i + 1.ToString());
                                                     txt1.Text = Ds.Tables[0].Rows[i].ItemArray[4].ToString();
                                                     txt1.TextMode = TextBoxMode.MultiLine;
@@ -1707,12 +1540,9 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                     if ((Request["Operacion"].ToString() == "Valida") || (Request["Operacion"].ToString() == "Control"))
                                                     {
                                                         if (oDetalle.IdProtocolo.IdTipoServicio.IdTipoServicio!=5)
-                                                        {
+                                                        {   //Caro Performance: se comenta por defecto la busqueda del resultado anterior 
 
-                                                            //Caro Performance: se comenta por defecto la busqueda del resultado anterior 
-
-                                                            string resultadoAnterior = "";// oDetalle.BuscarResultadoAnterior(oDetalle.IdSubItem, oDetalle.IdItem, true);
-                                                        
+                                                            string resultadoAnterior = "";// oDetalle.BuscarResultadoAnterior(oDetalle.IdSubItem, oDetalle.IdItem, true);                                                        
                                                         //        resultadoAnterior =   oDetalle.BuscarResultadoAnterior(oDetalle.IdSubItem, oDetalle.IdItem, true);
                                                         //    if (resultadoAnterior != "")
                                                         //{
@@ -1724,8 +1554,7 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                                 olblResultadoAnterior.Font.Size = FontUnit.Point(8);
                                                             olblResultadoAnterior.ForeColor = Color.Green;
                                                             olblResultadoAnterior.Visible = false;
-                                                            olblResultadoAnterior.ID = "ResAnterior"+ s_determinacion;
-                                                            //   olblResultadoAnterior.Width = Unit.Pixel(20);
+                                                            olblResultadoAnterior.ID = "ResAnterior"+ s_determinacion;                                                            
                                                             olblResultadoAnterior.Text = resultadoAnterior;
                                                             olblResultadoAnterior.Attributes.Add("onClick", "javascript: AntecedenteAnalisisView (" + s_determinacion + "," + s_idPaciente + ",790,420); return false");
                                                             objCellResultadoAnterior.Controls.Add(olblResultadoAnterior);
@@ -1734,11 +1563,9 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                     }
 
                                                     //Boton de desplegar y/o ocultar las opciones predefinidas para elegir.
-                                                    Anthem.ImageButton btnAddDetalle = new Anthem.ImageButton();
-                                                    //ImageButton btnAddDetalle = new ImageButton();
+                                                    Anthem.ImageButton btnAddDetalle = new Anthem.ImageButton();                                                    
                                                     btnAddDetalle.TabIndex = short.Parse("500");
                                                     //btnAddDetalle.AutoUpdateAfterCallBack = true;
-
                                                     btnAddDetalle.ID = "b" + m_idItem.ToString();
                                                     //btnAddDetalle.ID = "b" + m_idSuperItem+";"+ m_idItem.ToString();
                                                     btnAddDetalle.ToolTip = "Desplegar opciones";
@@ -1749,26 +1576,17 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
 
                                                 if ((estado > 0) && (Request["Operacion"].ToString() == "Carga")) //si esta controlado o validado pinta la celda
                                                     {
-                                                    btnAddDetalle.Enabled=false;
-                                                  //      chk1.BackColor = Color.GhostWhite;
-                                                    //    chk1.Enabled = false;
+                                                    btnAddDetalle.Enabled=false;                                                  
                                                         txt1.Enabled = false;
                                                     }
 
                                                     if ((estado == 2) && (Request["Operacion"].ToString() == "Control")) //si esta validado y entro a controlar no puedo modificar
-                                                    {
-                                                    //    chk1.BackColor = Color.GhostWhite;
-                                                      //  chk1.Enabled = false;
+                                                    {                                                    
                                                         btnAddDetalle.Enabled=false;
                                                         txt1.Enabled = false;
                                                     }
-
-
-
-
                                                     objCellResultado.Controls.Add(txt1);
                                                     objCellResultado.Controls.Add(chk1);
-
                                                     objCellResultado.Controls.Add(btnAddDetalle);
                                                     ////Habilitacion de observaciones
                                                     ImageButton btnObservacionDetalle2 = new ImageButton();
@@ -1778,7 +1596,6 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
 
                                                     if (oDetalle.Observaciones != "")//tiene observaciones
                                                     {
-
                                                         if (oDetalle.IdUsuarioValidaObservacion == 0)
                                                             btnObservacionDetalle2.ImageUrl = "~/App_Themes/default/images/obs_cargado.png";
                                                         else
@@ -1786,14 +1603,11 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                     }
                                                     else
                                                     {
-
                                                         btnObservacionDetalle2.ImageUrl = "~/App_Themes/default/images/obs_normal.png";
                                                     }
 
                                                     btnObservacionDetalle2.AlternateText = oDetalle.Observaciones;
                                                     btnObservacionDetalle2.ToolTip = "Observaciones para " + lbl1.Text.Replace("&nbsp;", "");
-
-
                                                     btnObservacionDetalle2.Attributes.Add("onClick", "javascript: ObservacionEdit (" + i_iddetalleProtocolo.ToString() + "," + oDetalle.IdProtocolo.IdTipoServicio.IdTipoServicio.ToString() + ",'" + Request["Operacion"].ToString() + "'); return false");
 
                                                     objCellObservaciones.Controls.Add(btnObservacionDetalle2);
@@ -1804,8 +1618,6 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                         ImageButton btnImagen = new ImageButton();
                                                         btnImagen.TabIndex = short.Parse("500");
                                                         btnImagen.ID = "IMG" + i_iddetalleProtocolo.ToString(); // Caro Performance
-
-
                                                         if (oDetalle.tieneAdjuntoNoVisible())//tiene observaciones
                                                         {
                                                             btnImagen.ImageUrl = "~/App_Themes/default/images/obs_cargado.png";
@@ -1824,10 +1636,6 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                                 btnImagen.ToolTip = "Subir adjunto  para " + lbl1.Text.Replace("&nbsp;", "");
                                                             }
                                                         }
-
-
-
-
                                                         btnImagen.Attributes.Add("onClick", "javascript: AdjuntoEdit (" + i_iddetalleProtocolo.ToString() + "," + oDetalle.IdProtocolo.IdTipoServicio.IdTipoServicio.ToString() + ",'" + Request["Operacion"].ToString() + "'); return false");
                                                         objCellImagenes.Controls.Add(btnImagen);
                                                     }
@@ -1873,15 +1681,12 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                 {
                                                     DropDownList ddl1 = new DropDownList();
                                                     ddl1.Width = Unit.Pixel(200);
-                                                    ddl1.ID = m_idItem.ToString();
-                                                    //ddl1.ID = m_idSuperItem + ";" + m_idItem.ToString();
+                                                    ddl1.ID = m_idItem.ToString();                                                    
                                                     ddl1.TabIndex = short.Parse(i + 1.ToString());
-
                                                     ListItem ItemSeleccion = new ListItem();
                                                     ItemSeleccion.Value = Ds.Tables[0].Rows[i].ItemArray[4].ToString();
                                                     ItemSeleccion.Text = Ds.Tables[0].Rows[i].ItemArray[4].ToString();
                                                     ddl1.Items.Add(ItemSeleccion);
-
                                                     foreach (ResultadoItem oResultado in resultados)
                                                     {
                                                         ListItem Item = new ListItem();
@@ -1891,24 +1696,19 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                         if (oResultado.ResultadoDefecto)
                                                             m_resultadoDefecto = oResultado.IdResultadoItem.ToString();
                                                     }
-
                                                     if ((m_resultadoDefecto != "") && (m_conResultado == "False"))
                                                     {
                                                         ddl1.SelectedValue = m_resultadoDefecto;
                                                     }
-
                                                     ddl1.SelectedIndexChanged += new EventHandler(ddl1_SelectedIndexChanged);
                                                     ddl1.Attributes.Add("onkeypress", "javascript:return Enter(this, event)");
 
-                                                    ///estad=0 Carga
-                                                    ///estado=1 control
-                                                    ///estado=2 valida
+                                                    ///estad=0 Carga  ///estado=1 control///estado=2 valida
                                                     if ((estado > 0) && (Request["Operacion"].ToString() == "Carga")) //si esta controlado o validado pinta la celda
                                                     {
                                                         ddl1.BackColor = Color.GhostWhite;
                                                         ddl1.Enabled = false;
                                                     }
-
                                                     if ((estado == 2) && (Request["Operacion"].ToString() == "Control")) //si esta validado y entro a controlar no puedo modificar
                                                     {
                                                         ddl1.BackColor = Color.GhostWhite;
@@ -1920,10 +1720,7 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                     if ((Request["Operacion"].ToString() == "Valida") || (Request["Operacion"].ToString() == "Control"))
                                                     {
                                                         if (oDetalle.IdProtocolo.IdTipoServicio.IdTipoServicio != 5)
-                                                        {
-
-
-                                                            //Caro Performance: se comenta por defecto la busqueda del resultado anterior
+                                                        {   //Caro Performance: se comenta por defecto la busqueda del resultado anterior
                                                             string resultadoAnterior = "";// oDetalle.BuscarResultadoAnterior(oDetalle.IdSubItem, oDetalle.IdItem, true);
                                                             //if (chkMostrarResultadosAnteriores.Checked)
                                                             //    resultadoAnterior = oDetalle.BuscarResultadoAnterior(oDetalle.IdSubItem, oDetalle.IdItem, true);
@@ -1933,8 +1730,7 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                                 Label olblResultadoAnterior = new Label();
                                                                 olblResultadoAnterior.TabIndex = short.Parse("500");
                                                                 olblResultadoAnterior.Font.Size = FontUnit.Point(8);
-                                                                olblResultadoAnterior.ToolTip = "Haga clic aquí para ver más datos.";
-                                                                //  olblResultadoAnterior.Font.Bold = true;
+                                                                olblResultadoAnterior.ToolTip = "Haga clic aquí para ver más datos.";                                                                
                                                                 olblResultadoAnterior.ForeColor = Color.Green;
                                                                 olblResultadoAnterior.Visible = false;
                                                                 olblResultadoAnterior.ID = "ResAnterior" + s_determinacion;
@@ -1944,37 +1740,23 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                                 objCellResultadoAnterior.Controls.Add(olblResultadoAnterior);
                                                             //}
                                                         }
-                                                    }
-
-                                               
-
-
+                                                    }                                               
                                                     ////Otra forma de observacion
                                                     ImageButton btnObservacionDetalle2 = new ImageButton();
                                                     btnObservacionDetalle2.TabIndex = short.Parse("500");
-                                                    btnObservacionDetalle2.ID = "OBS" + i_iddetalleProtocolo.ToString();
-                                                    //btnObservacionDetalle2.ID = "Obs2|" + oDetalle.IdDetalleProtocolo.ToString() + "|" + m_estadoObservacion.ToString();//  m_idItem.ToString();
-
+                                                    btnObservacionDetalle2.ID = "OBS" + i_iddetalleProtocolo.ToString();                                                    
                                                     if (oDetalle.Observaciones != "")//tiene observaciones
                                                     {
-
                                                         if (oDetalle.IdUsuarioValidaObservacion == 0)
                                                             btnObservacionDetalle2.ImageUrl = "~/App_Themes/default/images/obs_cargado.png";
                                                         else
                                                             btnObservacionDetalle2.ImageUrl = "~/App_Themes/default/images/obs_validado.png";
                                                     }
-                                                    else
-                                                    {
-
-                                                        btnObservacionDetalle2.ImageUrl = "~/App_Themes/default/images/obs_normal.png";
-                                                    }
-
+                                                    else                                                    
+                                                        btnObservacionDetalle2.ImageUrl = "~/App_Themes/default/images/obs_normal.png";                                                    
                                                     btnObservacionDetalle2.AlternateText = oDetalle.Observaciones;
-                                                    btnObservacionDetalle2.ToolTip = "Observaciones para " + lbl1.Text.Replace("&nbsp;", "");
-                                                    
-                                                    
+                                                    btnObservacionDetalle2.ToolTip = "Observaciones para " + lbl1.Text.Replace("&nbsp;", "");                                                                                                        
                                                     btnObservacionDetalle2.Attributes.Add("onClick", "javascript: ObservacionEdit (" + i_iddetalleProtocolo.ToString() + "," + oDetalle.IdProtocolo.IdTipoServicio.IdTipoServicio.ToString() +",'"+Request["Operacion"].ToString()+"'); return false");
-
                                                     objCellObservaciones.Controls.Add(btnObservacionDetalle2);
 
                                                     ////////////////////                                        
@@ -1983,9 +1765,7 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                     { 
                                                     ImageButton btnImagen = new ImageButton();
                                                     btnImagen.TabIndex = short.Parse("500");
-                                                    btnImagen.ID = "IMG" + i_iddetalleProtocolo.ToString();
-
-
+                                                    btnImagen.ID = "IMG" + i_iddetalleProtocolo.ToString();                                                        
                                                     if (oDetalle.tieneAdjuntoNoVisible())//tiene observaciones
                                                     {
                                                         btnImagen.ImageUrl = "~/App_Themes/default/images/obs_cargado.png";
@@ -2004,16 +1784,10 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                         btnImagen.ToolTip = "Subir adjunto  para " + lbl1.Text.Replace("&nbsp;", "");
                                                         }
                                                     }                                              
-                                                    
-                                                    
-
-
                                                     btnImagen.Attributes.Add("onClick", "javascript: AdjuntoEdit (" + i_iddetalleProtocolo.ToString() + "," + oDetalle.IdProtocolo.IdTipoServicio.IdTipoServicio.ToString() + ",'" + Request["Operacion"].ToString() + "'); return false");
                                                     objCellImagenes.Controls.Add(btnImagen);
                                                     }
                                                     // fin de imagenes adjuntas
-
-
                                                 }
                                             }
                                             else
@@ -2025,7 +1799,6 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                     olbl.Text = "";
                                                 else
                                                     olbl.Text = Ds.Tables[0].Rows[i].ItemArray[4].ToString();
-
                                                 objCellResultado.Controls.Add(olbl);
                                                 if (oDetalle.Observaciones != "")
                                                 {
@@ -2037,7 +1810,6 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                             }
                                         } //fin case 3
                                         break;
-
                                     case 1: //numerico
                                         {
                                             string expresionControlDecimales = oUtil.ExpresionFormato(int.Parse(m_formatoDecimal));
@@ -2046,36 +1818,26 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                             {
                                                 case "0":
                                                     {
-                                                        //expresionControlDecimales = "[-+]?\\d*";
-                                                     //   expresionControlDecimales = "[-+]?\\d+";
                                                         x = decimal.Parse(m_formato0);
                                                     }
                                                     break;
                                                 case "1":
-                                                    {
-                                                        //expresionControlDecimales = "[-+]?\\d*\\.?\\,?\\d{0,1}";
-                                                      //  expresionControlDecimales = "[-+]?\\d+\\.?\\,?\\d{0,1}";
+                                                    {                                                        
                                                         x = decimal.Parse(m_formato1);
                                                     }
                                                     break;
                                                 case "2":
-                                                    {
-                                                        //                                                        expresionControlDecimales = "[-+]?\\d*\\.?\\,?\\d{0,2}";
-                                                     //   expresionControlDecimales = "[-+]?\\d+\\.?\\,?\\d{0,2}";
+                                                    {                                                     
                                                         x = decimal.Parse(m_formato2);
                                                     }
                                                     break;
                                                 case "3":
-                                                    {
-                                                        //expresionControlDecimales = "[-+]?\\d*\\.?\\,?\\d{0,3}";
-                                                      //  expresionControlDecimales = "[-+]?\\d+\\.?\\,?\\d{0,3}";
+                                                    {                                                     
                                                         x = decimal.Parse(m_formato3);
                                                     }
                                                     break;
                                                 case "4":
-                                                    {
-                                                        //expresionControlDecimales = "[-+]?\\d*\\.?\\,?\\d{0,4}";
-                                                     //   expresionControlDecimales = "[-+]?\\d+\\.?\\,?\\d{0,4}";
+                                                    {                                                     
                                                         x = decimal.Parse(m_formato4);
                                                     }
                                                     break;
@@ -2092,15 +1854,10 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                 txt1.TabIndex = short.Parse(i + 1.ToString());
                                                 if (m_conResultado == "True") txt1.Text = x.ToString(System.Globalization.CultureInfo.InvariantCulture); 
                                                 if (m_conResultado == "False") txt1.Text = m_resultadoDefecto;
-                                                txt1.Width = Unit.Pixel(60);
-                                              
+                                                txt1.Width = Unit.Pixel(60);                                              
                                                 txt1.CssClass = "form-control input-sm";
-
-
                                                 if (Request["Operacion"].ToString() != "Carga") //validacion
-                                                {
-                                                    // if (VerificaValorReferencia(m_minimoReferencia, m_maximoReferencia, x, m_tipoValorReferencia))
-                                                    
+                                                {                                                    
                                                     if (oDetalle.VerificaValorReferencia(x))
                                                         txt1.ForeColor = Color.Black;
                                                     else
@@ -2109,12 +1866,7 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                         else txt1.ForeColor = Color.Black;
                                                     }
                                                 }
-
-                                               
-
-                                                //  objCellResultado.Controls.Add(imgAceptaValor);
                                                 objCellResultado.Controls.Add(txt1);
-
 
                                                 ///etiqueta de unidad de medida
                                                 Label olblUM = new Label();
@@ -2123,18 +1875,12 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                 olblUM.Text = unMedida;
                                                 objCellResultado.Controls.Add(olblUM);
                                                 olblUM.Visible = false;
-                                                //////////////////////////////////////////////////////
-
-                                             
+                                                //////////////////////////////////////////////////////                                             
                                                 if (oItem.TieneFormula()) //Si el item se calcula por formula se muestra inhabilitado
                                                 {
                                                     chkFormula.Visible = true;
                                                     lblFormula.Visible = true;
-                                                    btnAplicarFormula.Visible = true;
-                                                   
-                                                 
-
-
+                                                    btnAplicarFormula.Visible = true;                                                                                                    
                                                     /// seleccionar la formula a calcular
                                                     CheckBox ochkFormula = new CheckBox();
                                                     ochkFormula.Checked = true;                                                    
@@ -2185,15 +1931,12 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                 oValidaNumero.ControlToValidate = txt1.ID;
                                                 oValidaNumero.Text = "Formato incorrecto";
                                                 oValidaNumero.ValidationGroup = "0";
-                                                objCellResultado.Controls.Add(oValidaNumero);
-
-                                     
+                                                objCellResultado.Controls.Add(oValidaNumero);                                     
                                                 ////Otra forma de observacion
                                                 ImageButton    btnObservacionDetalle2 = new ImageButton();
                                                 btnObservacionDetalle2.TabIndex = short.Parse("500");
                                                 if (oDetalle.Observaciones != "")//tiene observaciones
                                                 {
-
                                                     if (oDetalle.IdUsuarioValidaObservacion == 0)
                                                         btnObservacionDetalle2.ImageUrl = "~/App_Themes/default/images/obs_cargado.png";
                                                     else
@@ -2201,32 +1944,24 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                 }
                                                 else
                                                 {
-
                                                     btnObservacionDetalle2.ImageUrl = "~/App_Themes/default/images/obs_normal.png";
                                                 }
                                                 btnObservacionDetalle2.ID = "OBS" + i_iddetalleProtocolo.ToString();
                                                 btnObservacionDetalle2.AlternateText = oDetalle.Observaciones;
                                                 btnObservacionDetalle2.ToolTip = "Observaciones para " + lbl1.Text.Replace("&nbsp;", "");
-                                                btnObservacionDetalle2.Attributes.Add("onClick", "javascript: ObservacionEdit (" + i_iddetalleProtocolo.ToString() + "," + oDetalle.IdProtocolo.IdTipoServicio.IdTipoServicio.ToString()   +",'"+Request["Operacion"].ToString()+"'); return false");
-                                                 
+                                                btnObservacionDetalle2.Attributes.Add("onClick", "javascript: ObservacionEdit (" + i_iddetalleProtocolo.ToString() + "," + oDetalle.IdProtocolo.IdTipoServicio.IdTipoServicio.ToString()   +",'"+Request["Operacion"].ToString()+"'); return false");                                                 
                                                 objCellObservaciones.Controls.Add(btnObservacionDetalle2);
                                                 
-                                                ////////////////////                                        
-
-
-
                                                 if ((estado > 0) && (Request["Operacion"].ToString() == "Carga")) //si esta controlado o validado pinta la celda
                                                 {
                                                     txt1.BackColor = Color.GhostWhite;
                                                     txt1.Enabled = false;
                                                 }
-
                                                 if ((estado == 2) && (Request["Operacion"].ToString() == "Control")) //si esta validado y entro a controlar no puedo modificar
                                                 {
                                                     txt1.BackColor = Color.GhostWhite;
                                                     txt1.Enabled = false;
                                                 }
-
                                                 ////////////////////                                        
                                                 ///IMAGENES ADJUNTAS
                                                 if (Request["Operacion"].ToString() != "HC")
@@ -2234,9 +1969,6 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                     ImageButton btnImagen = new ImageButton();
                                                     btnImagen.TabIndex = short.Parse("500");
                                                     btnImagen.ID = "IMG" + i_iddetalleProtocolo.ToString();
-
-
-
                                                     ///Caro Performance: buscar una sola vez cuantos adjuntos visibles y no visbles tiene
                                                     if (oDetalle.tieneAdjuntoNoVisible())//tiene observaciones
                                                     {
@@ -2256,10 +1988,6 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                             btnImagen.ToolTip = "Subir adjunto  para " + lbl1.Text.Replace("&nbsp;", "");
                                                         }
                                                     }
-
-
-
-
                                                     btnImagen.Attributes.Add("onClick", "javascript: AdjuntoEdit (" + i_iddetalleProtocolo.ToString() + "," + oDetalle.IdProtocolo.IdTipoServicio.IdTipoServicio.ToString() + ",'" + Request["Operacion"].ToString() + "'); return false");
                                                     objCellImagenes.Controls.Add(btnImagen);
                                                 }
@@ -2274,7 +2002,6 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                     olbl.Text = "";
                                                 else
                                                     olbl.Text = x.ToString(System.Globalization.CultureInfo.InvariantCulture) + " " + unMedida;
-
                                                 //                                                if (VerificaValorReferencia(m_minimoReferencia, m_maximoReferencia, x, m_tipoValorReferencia))
                                                 if (oDetalle.VerificaValorReferencia(x))
                                                     olbl.ForeColor = Color.Black;
@@ -2290,8 +2017,7 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                     if (olbl.Text == "")
                                                         olbl.Text = oDetalle.Observaciones;
                                                     else
-                                                        olbl.Text += Environment.NewLine + oDetalle.Observaciones;
-                                                    //objCellResultado.Controls.Add(olblObservaciones);
+                                                        olbl.Text += Environment.NewLine + oDetalle.Observaciones;                                                    
                                                 }
                                                 objCellResultado.Controls.Add(olbl);
                                             }
@@ -2323,7 +2049,6 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                 txt1.CssClass = "form-control input-sm";
 
                                                 if (m_conResultado == "False") txt1.Text = m_resultadoDefecto;
-
                                                 if ((estado > 0) && (Request["Operacion"].ToString() == "Carga")) //si esta controlado o validado pinta la celda
                                                 {
                                                     txt1.BackColor = Color.GhostWhite;
@@ -2340,8 +2065,7 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                 {
                                                     if (EsNumerico(txt1.Text))
                                                     {
-                                                        decimal x1 = decimal.Parse(txt1.Text.Replace(",", "."), System.Globalization.CultureInfo.InvariantCulture);
-                                                        // if (VerificaValorReferencia(m_minimoReferencia, m_maximoReferencia, x, m_tipoValorReferencia))
+                                                        decimal x1 = decimal.Parse(txt1.Text.Replace(",", "."), System.Globalization.CultureInfo.InvariantCulture);                                                        
                                                         if (oDetalle.VerificaValorReferencia(x1))
                                                             txt1.ForeColor = Color.Black;
                                                         else
@@ -2369,8 +2093,6 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                     ImageButton btnImagen = new ImageButton();
                                                     btnImagen.TabIndex = short.Parse("500");
                                                     btnImagen.ID = "IMG" + i_iddetalleProtocolo.ToString();
-
-
                                                     if (oDetalle.tieneAdjuntoNoVisible())//tiene observaciones
                                                     {
                                                         btnImagen.ImageUrl = "~/App_Themes/default/images/obs_cargado.png";
@@ -2389,10 +2111,6 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                             btnImagen.ToolTip = "Subir adjunto  para " + lbl1.Text.Replace("&nbsp;", "");
                                                         }
                                                     }
-
-
-
-
                                                     btnImagen.Attributes.Add("onClick", "javascript: AdjuntoEdit (" + i_iddetalleProtocolo.ToString() + "," + oDetalle.IdProtocolo.IdTipoServicio.IdTipoServicio.ToString() + ",'" + Request["Operacion"].ToString() + "'); return false");
                                                     objCellImagenes.Controls.Add(btnImagen);
                                                 }
@@ -2400,7 +2118,6 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                             }
                                             else
                                             {
-
                                                 Label olbl = new Label();
                                                 olbl.Font.Name = "Courier";
                                                 olbl.Font.Size = FontUnit.Point(9);
@@ -2410,14 +2127,11 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                                     olbl.Text = Ds.Tables[0].Rows[i].ItemArray[4].ToString();
                                                 objCellResultado.Controls.Add(olbl);
                                             }
-
                                             ////////////////////
                                             if ((Request["Operacion"].ToString() == "Valida") || (Request["Operacion"].ToString() == "Control"))
                                             {
                                                 if (oDetalle.IdProtocolo.IdTipoServicio.IdTipoServicio != 5)
-                                                {
-
-                                                    ///Caro Performance: sacar busqueda en modo simplificado
+                                                {                                                    ///Caro Performance: sacar busqueda en modo simplificado
                                                     string resultadoAnterior = ""; // oDetalle.BuscarResultadoAnterior(oDetalle.IdSubItem, oDetalle.IdItem, true);
                                                     //if (chkMostrarResultadosAnteriores.Checked)
                                                     //    resultadoAnterior = oDetalle.BuscarResultadoAnterior(oDetalle.IdSubItem, oDetalle.IdItem, true);
@@ -2442,7 +2156,6 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
 
                                         } // fin case 
                                         break;
-
                                 }//fin swicth
 
 
@@ -2481,9 +2194,7 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                         {
                                             if (Request["Operacion"].ToString() == "Valida")
                                             {
-                                                desvalidar = true;
-                                                //if (oDetalle.IdUsuarioValida == int.Parse(Session["idUsuarioValida"].ToString())) desvalidar = true;
-                                                //if (oDetalle.IdUsuarioPreValida == int.Parse(Session["idUsuarioValida"].ToString())) desvalidar = true;
+                                                desvalidar = true;                                              
                                             }
 
                                             if ((m_usuariovalida == "") && (oDetalle.IdUsuarioValidaObservacion > 0))
@@ -2500,24 +2211,13 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                             {
                                                 Usuario oUser = new Usuario();
                                                 oUser = (Usuario)oUser.Get(typeof(Usuario), oDetalle.IdUsuarioPreValida);
-
                                                 lblPersona.Text = "PreVal.: " + oUser.FirmaValidacion + " " + oDetalle.FechaPreValida.ToShortDateString() + " " + oDetalle.FechaPreValida.ToShortTimeString();
                                                 lblPersona.ForeColor = Color.Red;
                                             }
-
-
                                         }
                                         break;
-                                }
-
-
-
-
-
-                                /// 
-                                lblPersona.Font.Size = FontUnit.Point(6);
-                                //lblPersona.Font.Italic = true;
-
+                                }                                
+                                lblPersona.Font.Size = FontUnit.Point(6);                                
                                 if (oDetalle.IdUsuarioImpresion > 0)
                                 {
                                     System.Web.UI.WebControls.Image imgImp = new System.Web.UI.WebControls.Image();
@@ -2530,28 +2230,19 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                                 {
                                     CheckBox chk1 = new CheckBox();
                                     chk1.ID = "chk" + Ds.Tables[0].Rows[i].ItemArray[2].ToString();
-                                    if ((estado == 2) && (Request["Operacion"].ToString() == "Control")) //si esta validado y entro a controlar no puedo modificar
-                                    {
-                                        chk1.Visible = false;
-
-                                    }
+                                    if ((estado == 2) && (Request["Operacion"].ToString() == "Control")) //si esta validado y entro a controlar no puedo modificar                                    
+                                        chk1.Visible = false;                                    
                                     objCellValida.Controls.Add(chk1);
                                 }
 
                                 if (Request["Operacion"].ToString() != "HC")
                                 {
-
                                     Label lblUMedida = new Label();
-
                                     //lblUMedida.ID = "UM"+ m_idItem.ToString();
                                     lblUMedida.Font.Italic = true;
                                     lblUMedida.Font.Size = FontUnit.Point(8);
-
                                     lblUMedida.Text = unMedida;
-
-
                                     objCellUnMedida.Controls.Add(lblUMedida);
-
                                 }
 
 
@@ -2604,9 +2295,11 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
                 }*/
 
                 if (Request["idServicio"].ToString()!="6")
-                    { 
-                if ((Request["Operacion"].ToString() == "Valida") && (algovalidado == true)) // si es validacion y tiene algo validado
-                    btnRestringirAcceso.Visible = true;
+                { 
+                    if ((Request["Operacion"].ToString() == "Valida") && (algovalidado == true)) // si es validacion y tiene algo validado
+                        btnRestringirAcceso.Visible = true;
+                        imgPdf.Visible = true;
+                    ///no poner boton imprimir: caro
                 }
                 //else
                 //    btnRestringirAcceso.Visible = false;
@@ -2655,7 +2348,7 @@ WHERE     (PA.idPerfilAntibiotico = " + ddlPerfilAntibiotico.SelectedValue + ") 
 
 
             string m_ssql = @" SELECT idObservacionResultado , codigo  AS descripcion 
-                                FROM   LAB_ObservacionResultado where idTipoServicio=" +Request["idServicio"].ToString()+" and  baja=0 order by codigo " ;
+                                FROM   LAB_ObservacionResultado with (nolock) where idTipoServicio=" +Request["idServicio"].ToString()+" and  baja=0 order by codigo " ;
           
 
             if (tipo == "gral")

--- a/WebLab/Resultados/ResultadoItemEdit.aspx.cs
+++ b/WebLab/Resultados/ResultadoItemEdit.aspx.cs
@@ -22,6 +22,7 @@ using System.Net.Http;
 using System.Text;
 using System.Net;
 using System.IO;
+using System.Collections.Generic;
 
 namespace WebLab.Resultados
 {
@@ -715,8 +716,781 @@ namespace WebLab.Resultados
         {
           //  Marcar(false);
         }
-
         private void LlenarTabla(string p)
+        {
+            Item oItem = new Item();
+            oItem = (Item)oItem.Get(typeof(Item), int.Parse(p));
+
+
+            bool hiv = oItem.CodificaHiv;
+
+            DataTable dt = getDataSet(oItem.IdItem.ToString());
+            if (dt.Rows.Count > 0)
+            {
+                //lblCantidadRegistros.Text = dt.Rows.Count.ToString() + " protocolos encontrados ";
+
+                TableRow objFila_TITULO = new TableRow();
+                TableCell objCellProtocolo_TITULO = new TableCell();
+                TableCell objCellFecha_TITULO = new TableCell();
+                TableCell objCellPaciente_TITULO = new TableCell();
+                TableCell objCellResultado_TITULO = new TableCell();
+                TableCell objCellResultadoAnterior_TITULO = new TableCell();
+
+                TableCell objCellReferencia_TITULO = new TableCell();
+                TableCell objCellPersona_TITULO = new TableCell(); TableCell objCellValida_TITULO = new TableCell();
+
+                TableCell objCellObservaciones_TITULO = new TableCell();
+
+                Label lblTituloProtocolo = new Label();
+                lblTituloProtocolo.Text = "PROTOCOLO";
+                objCellProtocolo_TITULO.Controls.Add(lblTituloProtocolo);
+
+
+                Label lblTituloFecha = new Label();
+                lblTituloFecha.Text = "FECHA";
+                objCellFecha_TITULO.Controls.Add(lblTituloFecha);
+
+                Label lblTituloPaciente = new Label();
+                lblTituloPaciente.Text = "PACIENTE";
+                objCellPaciente_TITULO.Controls.Add(lblTituloPaciente);
+
+                Label lblTituloResultado = new Label();
+                lblTituloResultado.Text = "RESULTADO";
+                objCellResultado_TITULO.Controls.Add(lblTituloResultado);
+
+                Label lblTituloObservacionesResultado = new Label();
+                lblTituloObservacionesResultado.Text = "OBS.";
+                objCellObservaciones_TITULO.Controls.Add(lblTituloObservacionesResultado);
+
+                Label lblResultadoAnterior = new Label();
+                lblResultadoAnterior.Text = "R.ANTER.";
+                objCellResultadoAnterior_TITULO.Controls.Add(lblResultadoAnterior);
+
+                Label lblTituloReferencia = new Label();
+                lblTituloReferencia.Text = "REFERENCIA|METODO";
+                objCellReferencia_TITULO.Controls.Add(lblTituloReferencia);
+
+                Label lblCargadoPor = new Label();
+                lblCargadoPor.Text = "ESTADO";
+                objCellPersona_TITULO.Controls.Add(lblCargadoPor);
+
+
+                Label lblValida = new Label();
+
+                if (Request["Operacion"].ToString() == "Valida")
+                    lblValida.Text = "VAL";
+
+                objCellValida_TITULO.Controls.Add(lblValida);
+                objFila_TITULO.Cells.Add(objCellProtocolo_TITULO);
+                objFila_TITULO.Cells.Add(objCellFecha_TITULO);
+                objFila_TITULO.Cells.Add(objCellPaciente_TITULO);
+                objFila_TITULO.Cells.Add(objCellResultado_TITULO);
+
+                if (Request["Operacion"].ToString() == "Valida") objFila_TITULO.Cells.Add(objCellResultadoAnterior_TITULO);
+                objFila_TITULO.Cells.Add(objCellReferencia_TITULO);
+                objFila_TITULO.Cells.Add(objCellPersona_TITULO);
+
+
+                if (Request["Operacion"].ToString() == "Valida")
+                {
+                    objFila_TITULO.Cells.Add(objCellValida_TITULO);
+                }
+
+                objFila_TITULO.Cells.Add(objCellObservaciones_TITULO);
+                objFila_TITULO.CssClass = "myLabelIzquierda";
+                objFila_TITULO.BackColor = Color.Gainsboro; //.DarkBlue;// "#F2F2FF";
+
+                Master.FindControl("ContentPlaceHolder1").FindControl("Panel1").Controls.Add(tContenido);
+
+                tContenido.Controls.Add(objFila_TITULO);//.Rows.Add(objRow);    
+
+                ISession session = NHibernateHttpModule.CurrentSession;
+
+                // 🔹 1. IDs de Detalle
+                var listaDetalleIds = dt.AsEnumerable()
+                    .Select(r => r[3])
+                    .Where(x => x != DBNull.Value)
+                    .Select(x => Convert.ToInt32(x))
+                    .Distinct()
+                    .ToList();
+
+                // 🔹 2. Traer TODOS los detalles de una
+                var listaDetallesRaw = session.CreateQuery(
+                    @"FROM DetalleProtocolo dp 
+      JOIN FETCH dp.IdProtocolo 
+      JOIN FETCH dp.IdProtocolo.IdPaciente
+      JOIN FETCH dp.IdSubItem
+      WHERE dp.IdDetalleProtocolo IN (:ids)")
+                    .SetParameterList("ids", listaDetalleIds)
+                    .List();
+
+                var listaDetalles = listaDetallesRaw.Cast<DetalleProtocolo>().ToList();
+
+                // 🔹 3. Indexar detalles
+                var dictDetalles = listaDetalles.ToDictionary(x => x.IdDetalleProtocolo);
+
+                // 🔹 4. Traer resultados UNA sola vez
+                var listaResultadosRaw = session.CreateQuery(
+                    @"FROM ResultadoItem r
+      WHERE r.IdItem = :item
+      AND r.IdEfector = :efector
+      AND r.Baja = :baja")
+                    .SetEntity("item", oItem)
+                    .SetEntity("efector", oUser.IdEfector)
+                    .SetBoolean("baja", false)
+                    .List();
+
+                var listaResultados = listaResultadosRaw.Cast<ResultadoItem>().ToList();
+                var dictResultados = listaResultados
+    .GroupBy(x => x.IdItem.IdItem)
+    .ToDictionary(g => g.Key, g => g.ToList());
+                /*fin del cambio*/
+
+                for (int i = 0; i < dt.Rows.Count; i++)
+                {
+                    string s_valorReferencia = dt.Rows[i].ItemArray[9].ToString();                 
+                    string s_idDetalleProtocolo = dt.Rows[i].ItemArray[3].ToString();
+                    /*   DetalleProtocolo oDetalle = new DetalleProtocolo();
+                       oDetalle = (DetalleProtocolo)oDetalle.Get(typeof(DetalleProtocolo), int.Parse(s_idDetalleProtocolo));
+                       */
+                    DetalleProtocolo oDetalle;
+                    if (!dictDetalles.TryGetValue(int.Parse(s_idDetalleProtocolo), out oDetalle))
+                        continue;
+
+                    string s_idProtocolo = oDetalle.IdProtocolo.ToString();
+                    string s_fecha = oDetalle.IdProtocolo.Fecha.ToShortDateString();                    
+                    string s_numero = oDetalle.IdProtocolo.Numero.ToString();
+                    string s_numeroOrigen = oDetalle.IdProtocolo.NumeroOrigen;
+                    if (s_numeroOrigen != "") s_numero = s_numero + "-" + s_numeroOrigen;
+                    string numerodocumento = "";
+                    string apellido = "";
+                    string nombre = "";
+                    string s_paciente = "";
+                    if (oDetalle.IdProtocolo.IdPaciente.IdPaciente > 0)
+                    {
+                        if (oDetalle.IdProtocolo.IdPaciente.IdEstado == 2) numerodocumento = "(Temporal)";
+                        else numerodocumento = oDetalle.IdProtocolo.IdPaciente.NumeroDocumento.ToString();
+                        apellido = oDetalle.IdProtocolo.IdPaciente.Apellido.ToUpper();
+                        nombre = oDetalle.IdProtocolo.IdPaciente.Nombre.ToUpper();
+                        s_paciente = "";
+
+
+                        if (hiv) //datosPaciente = " upper(P.sexo+substring(Pac.nombre,1,2)+SUBSTRING(Pac.apellido, 1,2)+REPLACE ( CONVERT(varchar(10), Pac.fechaNacimiento,103),'/','')) ";
+                            s_paciente = oDetalle.IdProtocolo.getCodificaHiv(""); // oDetalle.IdProtocolo.IdPaciente.getSexo().Substring(0, 1) + nombre.Substring(0, 2) + apellido.Substring(0, 2) + oDetalle.IdProtocolo.IdPaciente.FechaNacimiento.ToShortDateString().Replace("/", "");
+                        else
+                            if (oDetalle.IdProtocolo.IdTipoServicio.IdTipoServicio == 4)
+                                s_paciente = oDetalle.IdProtocolo.getDatosParentesco();
+                            else
+                                s_paciente = numerodocumento.ToUpper() + " - " + apellido.ToUpper() + " " + nombre.ToUpper();
+
+                    }
+                    //    string s_embarazada = oDetalle.IdProtocolo.GetDiagnostico();
+                    string m_formato0 = dt.Rows[i].ItemArray[4].ToString();
+                    string m_formato1 = dt.Rows[i].ItemArray[5].ToString();
+                    string m_formato2 = dt.Rows[i].ItemArray[6].ToString();
+                    string m_formato3 = dt.Rows[i].ItemArray[7].ToString();
+                    string m_formato4 = dt.Rows[i].ItemArray[8].ToString();
+                    int estado = 0;
+
+                    if (oDetalle.IdUsuarioValida > 0)
+                        estado = 2;
+
+                    if (oDetalle.IdUsuarioPreValida > 0)
+                        estado = 2;
+
+                    if (oDetalle.IdUsuarioControl > 0)
+                        estado = 2;                    
+                    string m_observacionReferencia = dt.Rows[i].ItemArray[16].ToString();
+
+                    string m_tipoValorReferencia = dt.Rows[i].ItemArray[12].ToString();
+                    string m_metodo = dt.Rows[i].ItemArray[11].ToString();                    
+                    string s_resultadoCar = dt.Rows[i].ItemArray[13].ToString();
+                    string s_conResultado = dt.Rows[i].ItemArray[14].ToString();
+
+                    if (s_conResultado == "False") { s_conResultado = "0"; }
+                    else { s_conResultado = "1"; }
+
+
+                    string s_Validado = "0";
+                    string s_usuario = "";
+
+
+                    if (oDetalle.IdUsuarioValida > 0)                    
+                    {
+                        s_usuario = "Val.: " + dt.Rows[i].ItemArray[18].ToString() + " " + oDetalle.FechaValida.ToShortDateString() + " " + oDetalle.FechaValida.ToShortTimeString();
+                        s_Validado = "2";
+                    }
+                    else
+                    {
+                        if (oDetalle.IdUsuarioPreValida > 0)
+                        {
+                            Usuario oUser = new Usuario();
+                            oUser = (Usuario)oUser.Get(typeof(Usuario), oDetalle.IdUsuarioPreValida);
+
+                            s_usuario = "PreVal.: " + oUser.FirmaValidacion + " " + oDetalle.FechaPreValida.ToShortDateString() + " " + oDetalle.FechaPreValida.ToShortTimeString();
+                            s_Validado = "2";
+                        }
+                        else
+                        {
+                            if (oDetalle.IdUsuarioControl > 0)
+                            //   if (dt.Rows[i].ItemArray[19].ToString() != "")//  usuario control                    
+                            {
+                                s_usuario = "Ctrl: " + dt.Rows[i].ItemArray[19].ToString();
+                                s_Validado = "1";
+                            }
+                            else
+                            {
+                                if (dt.Rows[i].ItemArray[17].ToString() != "")
+                                    s_usuario = "Carg.: " + dt.Rows[i].ItemArray[17].ToString() + " " + oDetalle.FechaResultado.ToShortDateString() + " " + oDetalle.FechaResultado.ToShortTimeString();  /// Ds.Tables[0].Rows[i].ItemArray[1].ToString();                                                                                                                                                                                                                              
+                                else
+                                {
+
+                                    if ((oDetalle.Enviado == 2) && (estado != 1))
+
+                                        s_usuario = "AUTOMÁTICO: " + oDetalle.FechaResultado.ToShortDateString() + " " + oDetalle.FechaResultado.ToShortTimeString();
+                                    else
+                                        s_usuario = "";
+                                }
+                            }
+                        }
+                    }
+
+
+                    TableRow objFila = new TableRow();
+                    TableCell objCellProtocolo = new TableCell();
+                    TableCell objCellFecha = new TableCell();
+                    TableCell objCellPaciente = new TableCell();
+                    TableCell objCellResultado = new TableCell();
+                    TableCell objCellReferencia = new TableCell();
+                    TableCell objCellValida = new TableCell();
+                    TableCell objCellPersona = new TableCell();
+                    TableCell objCellObservaciones = new TableCell();
+                    TableCell objCellResultadoAnterior = new TableCell();
+
+                    Label olblProtocolo = new Label();
+                    olblProtocolo.Font.Name = "Arial";
+                    olblProtocolo.Font.Size = FontUnit.Point(10);
+                    olblProtocolo.Text = s_numero;
+                    olblProtocolo.Font.Bold = true;                    
+                    objCellProtocolo.BackColor = Color.Beige;
+                    objCellProtocolo.Controls.Add(olblProtocolo);
+
+                    Label olblFecha = new Label();
+                    olblFecha.Text = s_fecha;
+                    olblFecha.Font.Name = "Arial";
+                    olblFecha.Font.Size = FontUnit.Point(8);
+                    objCellFecha.Controls.Add(olblFecha);
+
+
+                    Label olblPaciente = new Label();
+                    olblPaciente.Font.Name = "Arial";
+                    olblPaciente.Font.Size = FontUnit.Point(9);
+                    olblPaciente.Text = s_paciente;
+
+                    objCellPaciente.Controls.Add(olblPaciente);                    
+                    if (Request["Operacion"].ToString() == "Valida") /// Solo en la validacion
+                    {
+                        ImageButton btnAddDiagnostico = new ImageButton();
+                        btnAddDiagnostico.TabIndex = short.Parse("500");                        
+                        btnAddDiagnostico.ID = "d" + s_idDetalleProtocolo;
+                        btnAddDiagnostico.ToolTip = "Agregar/quitar Diagnostico del paciente.";
+                        btnAddDiagnostico.ImageUrl = "~/App_Themes/default/images/add.png";                        
+                        btnAddDiagnostico.Attributes.Add("onClick", "javascript: editDiagnostico (" + oDetalle.IdProtocolo.IdProtocolo.ToString() + "); return false");                        
+                        objCellProtocolo.Controls.Add(btnAddDiagnostico);
+                    }
+                    decimal x = 0;
+                    switch (oItem.IdTipoResultado)
+                    {//tipoResultado
+
+                        case 4://Lista predefinida de resultados con seleccion multiple 
+                            {
+                                /*   string m_resultadoDefecto = "";
+                                   ///busqueda de resultado por defecto solo si no tiene resultado cargado
+                                   if (s_conResultado == "0")// sin resultado
+                                   {
+                                       ISession m_session = NHibernateHttpModule.CurrentSession;
+                                       ICriteria crit = m_session.CreateCriteria(typeof(ResultadoItem));
+                                       crit.Add(Expression.Eq("IdItem", oItem));
+                                       crit.Add(Expression.Eq("IdEfector", oUser.IdEfector));
+                                       crit.Add(Expression.Eq("Baja", false));
+                                       ///      crit.AddOrder(Order.Asc("Resultado")); /// el orden lo define el usuario
+                                       ///Si tiene resultados predeterminados muestra un combo
+                                       IList resultados = crit.List();
+                                       foreach (ResultadoItem oResultado in resultados)
+                                       {
+                                           ListItem Item = new ListItem();
+                                           Item.Value = oResultado.IdResultadoItem.ToString();
+                                           Item.Text = oResultado.Resultado;
+
+                                           if (oResultado.ResultadoDefecto)
+                                               m_resultadoDefecto = oResultado.Resultado;
+                                       }
+                                   }
+                                   */
+                                string m_resultadoDefecto = "";
+
+                                // 🔹 Obtener resultados desde memoria (SIN QUERY)
+                                List<ResultadoItem> resultados = null;
+                                dictResultados.TryGetValue(oItem.IdItem, out resultados);
+
+                                ///busqueda de resultado por defecto solo si no tiene resultado cargado
+                                if (s_conResultado == "0" && resultados != null)
+                                {
+                                    foreach (ResultadoItem oResultado in resultados)
+                                    {
+                                        if (oResultado.ResultadoDefecto)
+                                            m_resultadoDefecto = oResultado.Resultado;
+                                    }
+                                }
+
+
+                                TextBox txt1 = new TextBox();
+                                txt1.ID = s_idDetalleProtocolo;
+                                txt1.ReadOnly = true;// no es posible editar como texto, sino que agregar /quitar desde las opciones
+                                txt1.TabIndex = short.Parse(i + 1.ToString());
+                                txt1.Text = s_resultadoCar;
+                                txt1.TextMode = TextBoxMode.MultiLine;
+                                txt1.Width = Unit.Percentage(95);
+                                txt1.Rows = 2;
+                                txt1.MaxLength = 200;
+                                txt1.ToolTip = s_resultadoCar;
+                                //txt1.CssClass = "myTexto";
+                                if (s_conResultado == "0")// sin resultado
+                                    txt1.Text = m_resultadoDefecto;
+
+                                ///agrega boton para seleccionar las opciones
+                                ImageButton btnAddDetalle = new ImageButton();
+                                btnAddDetalle.TabIndex = short.Parse("500");
+                                //btnAddDetalle.AutoUpdateAfterCallBack = true;
+                                btnAddDetalle.ID = "b" + s_idDetalleProtocolo;
+                                btnAddDetalle.ToolTip = "Desplegar opciones";
+                                btnAddDetalle.ImageUrl = "~/App_Themes/default/images/add.png";
+                                //btnObservacionDetalle2.Attributes.Add("onClick", "javascript: ObservacionEdit (" + oDetalle.IdDetalleProtocolo.ToString() + "," + oDetalle.IdProtocolo.IdTipoServicio.IdTipoServicio.ToString() + ",'" + Request["Operacion"].ToString() + "'); return false");
+                                btnAddDetalle.Attributes.Add("onClick", "javascript: PredefinidoSelect (" + oDetalle.IdDetalleProtocolo.ToString() + ",'" + Request["Operacion"].ToString() + "'); return false");
+                                //btnAddDetalle.Click += new ImageClickEventHandler(btnAddDetalle_Click);
+
+                                if (s_Validado != "0")
+                                {
+                                    txt1.BackColor = Color.LightBlue;
+                                    if (Request["Operacion"].ToString() == "Carga")
+                                    {
+                                        txt1.Enabled = false;// btnAddDetalle.Enabled = false; 
+                                    }
+                                }
+
+
+
+                                objCellResultado.Controls.Add(txt1);
+                                objCellResultado.Controls.Add(btnAddDetalle);
+
+                                ////Otra forma de observacion
+                                ImageButton btnObservacionDetalle2 = new ImageButton();
+                                btnObservacionDetalle2.TabIndex = short.Parse("500");
+
+                                btnObservacionDetalle2.ID = "Obs2|" + oDetalle.IdDetalleProtocolo.ToString(); // +"|" + m_estadoObservacion.ToString();//  m_idItem.ToString();
+
+                                if (oDetalle.Observaciones != "")//tiene observaciones
+                                {
+
+                                    if (oDetalle.IdUsuarioValidaObservacion == 0)
+                                        btnObservacionDetalle2.ImageUrl = "~/App_Themes/default/images/obs_cargado.png";
+                                    else
+                                        btnObservacionDetalle2.ImageUrl = "~/App_Themes/default/images/obs_validado.png";
+                                }
+                                else
+                                {
+
+                                    btnObservacionDetalle2.ImageUrl = "~/App_Themes/default/images/obs_normal.png";
+                                }
+
+                                btnObservacionDetalle2.AlternateText = oDetalle.Observaciones;
+                                //  btnObservacionDetalle2.ToolTip = "Observaciones para " + lbl1.Text.Replace("&nbsp;", "");
+                                btnObservacionDetalle2.Attributes.Add("onClick", "javascript: ObservacionEdit (" + oDetalle.IdDetalleProtocolo.ToString() + "," + oDetalle.IdProtocolo.IdTipoServicio.IdTipoServicio.ToString() + ",'" + Request["Operacion"].ToString() + "'); return false");
+
+                                objCellObservaciones.Controls.Add(btnObservacionDetalle2);
+
+                            } //fin case 4
+
+                            break;
+
+                        case 3://Lista predefinida de resultados
+                            {
+                                // 🔹 Obtener resultados desde memoria (SIN QUERY)
+                                List<ResultadoItem> resultados = null;
+                                dictResultados.TryGetValue(oItem.IdItem, out resultados);
+
+                                if (resultados != null && resultados.Count > 0)
+                                {
+                                    DropDownList ddl1 = new DropDownList();
+                                    ddl1.ID = s_idDetalleProtocolo;
+
+                                    // 🔹 Item vacío
+                                    ddl1.Items.Add(new ListItem("", "0"));
+
+                                    string m_resultadoDefecto = "";
+
+                                    foreach (ResultadoItem oResultado in resultados)
+                                    {
+                                        ddl1.Items.Add(new ListItem(
+                                            oResultado.Resultado,
+                                            oResultado.IdResultadoItem.ToString()
+                                        ));
+
+                                        if (oResultado.ResultadoDefecto)
+                                            m_resultadoDefecto = oResultado.IdResultadoItem.ToString();
+                                    }
+
+                                    // 🔹 Selección
+                                    if (s_conResultado == "0")// sin resultado
+                                    {
+                                        if (!string.IsNullOrEmpty(m_resultadoDefecto))
+                                            ddl1.SelectedValue = m_resultadoDefecto;
+                                    }
+                                    else
+                                    {
+                                        var itemSel = ddl1.Items.FindByText(s_resultadoCar);
+                                        if (itemSel != null)
+                                            ddl1.SelectedValue = itemSel.Value;
+                                    }
+
+                                    // 🔹 Estado validado
+                                    if (s_Validado != "0")
+                                    {
+                                        ddl1.BackColor = Color.LightBlue;
+
+                                        if (Request["Operacion"].ToString() == "Carga")
+                                            ddl1.Enabled = false;
+                                    }
+
+                                    ddl1.SelectedIndexChanged += new EventHandler(ddl1_SelectedIndexChanged);
+
+                                    objCellResultado.Controls.Add(ddl1);
+                                }
+
+
+                                /////////////////Resultado Anterior
+                                if (Request["Operacion"].ToString() == "Valida")
+                                {
+                                    //string resultadoAnterior = oDetalle.BuscarResultadoAnterior(oDetalle.IdSubItem, oDetalle.IdItem, true);
+                                    //if (resultadoAnterior != "")
+                                    //{
+
+                                    string resultadoAnterior = "";
+                                    Label olblResultadoAnterior = new Label();
+                                    olblResultadoAnterior.Font.Size = FontUnit.Point(8);                                    
+                                    olblResultadoAnterior.ForeColor = Color.Green;
+                                    olblResultadoAnterior.Width = Unit.Pixel(20);
+                                    olblResultadoAnterior.Text = resultadoAnterior;
+                                    olblResultadoAnterior.ID = "ResAnterior" + oDetalle.IdSubItem.IdItem.ToString() + "_" + oDetalle.IdProtocolo.IdProtocolo.ToString();
+                                    olblResultadoAnterior.ToolTip = "Haga clic aquí para ver más datos.";
+                                    olblResultadoAnterior.Attributes.Add("onClick", "javascript: AntecedenteAnalisisView (" + oDetalle.IdSubItem.IdItem.ToString() + "," + oDetalle.IdProtocolo.IdPaciente.IdPaciente.ToString() + ",790,400); return false");
+
+                                    objCellResultadoAnterior.Controls.Add(olblResultadoAnterior);
+
+                                    //}
+                                }
+                                //////////////////////
+                                ////Otra forma de observacion
+                                ImageButton btnObservacionDetalle2 = new ImageButton();
+                                btnObservacionDetalle2.TabIndex = short.Parse("500");
+
+                                btnObservacionDetalle2.ID = "Obs2|" + oDetalle.IdDetalleProtocolo.ToString(); // +"|" + m_estadoObservacion.ToString();//  m_idItem.ToString();
+
+                                if (oDetalle.Observaciones != "")//tiene observaciones
+                                {
+
+                                    if (oDetalle.IdUsuarioValidaObservacion == 0)
+                                        btnObservacionDetalle2.ImageUrl = "~/App_Themes/default/images/obs_cargado.png";
+                                    else
+                                        btnObservacionDetalle2.ImageUrl = "~/App_Themes/default/images/obs_validado.png";
+                                }
+                                else
+                                {
+
+                                    btnObservacionDetalle2.ImageUrl = "~/App_Themes/default/images/obs_normal.png";
+                                }
+
+                                btnObservacionDetalle2.AlternateText = oDetalle.Observaciones;
+                                //  btnObservacionDetalle2.ToolTip = "Observaciones para " + lbl1.Text.Replace("&nbsp;", "");
+                                btnObservacionDetalle2.Attributes.Add("onClick", "javascript: ObservacionEdit (" + oDetalle.IdDetalleProtocolo.ToString() + "," + oDetalle.IdProtocolo.IdTipoServicio.IdTipoServicio.ToString() + ",'" + Request["Operacion"].ToString() + "'); return false");
+
+                                objCellObservaciones.Controls.Add(btnObservacionDetalle2);
+
+                                ////////////////////                                        
+
+                            } //fin case 3
+                            break;
+
+                        case 1: //numerico
+                            {
+                                Utility outil = new Utility();
+                                string expresionControlDecimales = outil.ExpresionFormato(oItem.FormatoDecimal);                            
+                              
+                                string valor = "";
+
+                                // 🔹 Unificar lógica (sin 5 cases)
+                                switch (oItem.FormatoDecimal)
+                                {
+                                    case 0: valor = m_formato0; break;
+                                    case 1: valor = m_formato1; break;
+                                    case 2: valor = m_formato2; break;
+                                    case 3: valor = m_formato3; break;
+                                    case 4: valor = m_formato4; break;
+                                }
+
+                                if (!string.IsNullOrEmpty(valor) && outil.EsNumerico(valor))
+                                {
+                                    decimal.TryParse(valor, System.Globalization.NumberStyles.Any,
+                                        System.Globalization.CultureInfo.InvariantCulture, out x);
+                                }
+
+                                TextBox txt1 = new TextBox();
+                                txt1.ID = s_idDetalleProtocolo;
+                                if (s_conResultado == "0")// sin resultado
+                                    txt1.Text = oItem.ResultadoDefecto;
+                                else
+                                    txt1.Text = x.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+                                //    txt1.Text = val.Replace(".", "");
+                                txt1.Width = Unit.Pixel(60);
+                                txt1.CssClass = "myTexto";
+                                txt1.Attributes.Add("onkeypress", "javascript:return Enter(this, event)");
+
+                                if (s_Validado != "0")
+                                {
+                                    txt1.BackColor = Color.LightBlue;
+                                    if (Request["Operacion"].ToString() == "Carga")
+                                    { txt1.Enabled = false; }
+                                }
+
+
+
+                                objCellResultado.Controls.Add(txt1);
+
+                                RegularExpressionValidator oValidaNumero = new RegularExpressionValidator();
+                                oValidaNumero.ValidationExpression = expresionControlDecimales;
+                                oValidaNumero.ControlToValidate = txt1.ID;
+                                oValidaNumero.Text = "Formato incorrecto";
+                                oValidaNumero.ValidationGroup = "0";
+
+                                objCellResultado.Controls.Add(oValidaNumero);
+
+                                /////////////////Resultado Anterior
+                                if (Request["Operacion"].ToString() == "Valida")
+                                {
+                                    string resultadoAnterior = "";// oDetalle.BuscarResultadoAnterior(oDetalle.IdSubItem, oDetalle.IdItem,true);
+                                                                  /*if (resultadoAnterior != "")
+                                                                  {*/
+                                    Label olblResultadoAnterior = new Label();
+                                    olblResultadoAnterior.Font.Size = FontUnit.Point(8);
+                                    //olblResultadoAnterior.Font.Bold = true;
+                                    olblResultadoAnterior.ForeColor = Color.Green;
+                                    olblResultadoAnterior.Width = Unit.Pixel(20);
+                                    olblResultadoAnterior.Text = resultadoAnterior;
+                                    olblResultadoAnterior.ToolTip = "Haga clic aquí para ver gráfico de evolución.";
+                                    olblResultadoAnterior.ID = "ResAnterior" + oDetalle.IdSubItem.IdItem.ToString() + "_" + oDetalle.IdProtocolo.IdProtocolo.ToString();
+                                    olblResultadoAnterior.Attributes.Add("onClick", "javascript: AntecedenteAnalisisView (" + oDetalle.IdSubItem.IdItem.ToString() + "," + oDetalle.IdProtocolo.IdPaciente.IdPaciente.ToString() + ",790,420); return false");
+
+                                    objCellResultadoAnterior.Controls.Add(olblResultadoAnterior);
+
+
+                                    //  }
+                                }
+                                //////////////////////
+                                ////Otra forma de observacion
+                                ImageButton btnObservacionDetalle2 = new ImageButton();
+                                btnObservacionDetalle2.TabIndex = short.Parse("500");
+                                btnObservacionDetalle2.ID = "Obs2|" + oDetalle.IdDetalleProtocolo.ToString();// +"|" + m_estadoObservacion.ToString();//  m_idItem.ToString();
+                                if (oDetalle.Observaciones != "")//tiene observaciones
+                                {
+                                    if (oDetalle.IdUsuarioValidaObservacion == 0)
+                                        btnObservacionDetalle2.ImageUrl = "~/App_Themes/default/images/obs_cargado.png";
+                                    else
+                                        btnObservacionDetalle2.ImageUrl = "~/App_Themes/default/images/obs_validado.png";
+                                }
+                                else                                
+                                    btnObservacionDetalle2.ImageUrl = "~/App_Themes/default/images/obs_normal.png";                                
+
+                                btnObservacionDetalle2.AlternateText = oDetalle.Observaciones;                                
+                                btnObservacionDetalle2.Attributes.Add("onClick", "javascript: ObservacionEdit (" + oDetalle.IdDetalleProtocolo.ToString() + "," + oDetalle.IdProtocolo.IdTipoServicio.IdTipoServicio.ToString() + ",'" + Request["Operacion"].ToString() + "'); return false");
+                                objCellObservaciones.Controls.Add(btnObservacionDetalle2);
+                                
+                            }
+                            break;
+                        case 2: //texto
+                            {
+                                TextBox txt1 = new TextBox();
+                                txt1.ID = s_idDetalleProtocolo;
+                                if (s_conResultado == "0")// sin resultado
+                                    txt1.Text = oItem.ResultadoDefecto;
+                                else
+                                {
+                                    if (s_resultadoCar == "")
+                                    {
+                                        string resNum = oDetalle.ResultadoNum.ToString();
+                                        if ((s_resultadoCar == "") && (oDetalle.Enviado == 2) && (oDetalle.IdUsuarioValida == 0) && (oDetalle.IdUsuarioResultado == 0)) // automatico
+                                        {
+                                            if (resNum != "") txt1.Text = resNum.Substring(0, resNum.Length - 2).Replace(",", ".");
+                                        }
+                                        else
+                                            if (oDetalle.Enviado == 2) { if (oDetalle.Observaciones != "") txt1.Text = oDetalle.Observaciones; }
+                                    }
+                                    else
+                                        txt1.Text = s_resultadoCar;
+                                }
+                                txt1.TextMode = TextBoxMode.MultiLine;
+                                txt1.Width = Unit.Percentage(80);
+                                txt1.Rows = 1;
+                                txt1.MaxLength = 200;
+                                txt1.CssClass = "myTexto";
+
+
+                                if (s_Validado != "0")
+                                {
+                                    txt1.BackColor = Color.LightBlue;
+                                    if (Request["Operacion"].ToString() == "Carga")
+                                    { txt1.Enabled = false; }
+                                }
+
+                                Master.FindControl("ContentPlaceHolder1").FindControl("Panel1").Controls.Add(txt1);
+
+                                objCellResultado.Controls.Add(txt1);
+
+
+                                /////////////////Resultado Anterior
+                                if (Request["Operacion"].ToString() == "Valida")
+                                {
+                                    string resultadoAnterior = "";// oDetalle.BuscarResultadoAnterior(oDetalle.IdSubItem, oDetalle.IdItem, true);
+                                                                  //if (resultadoAnterior != "")
+                                                                  //{
+                                    Label olblResultadoAnterior = new Label();
+                                    olblResultadoAnterior.Font.Size = FontUnit.Point(8);
+                                    //olblResultadoAnterior.Font.Bold = true;
+                                    olblResultadoAnterior.ForeColor = Color.Green;
+                                    olblResultadoAnterior.Width = Unit.Pixel(20);
+                                    olblResultadoAnterior.Text = resultadoAnterior;
+                                    olblResultadoAnterior.ToolTip = "Haga clic aquí para ver más datos.";
+                                    olblResultadoAnterior.ID = "ResAnterior" + oDetalle.IdSubItem.IdItem.ToString() + "_" + oDetalle.IdProtocolo.IdProtocolo.ToString();
+                                    olblResultadoAnterior.Attributes.Add("onClick", "javascript: AntecedenteAnalisisView (" + oDetalle.IdSubItem.IdItem.ToString() + "," + oDetalle.IdProtocolo.IdPaciente.IdPaciente.ToString() + ",790,400); return false");
+
+
+                                    objCellResultadoAnterior.Controls.Add(olblResultadoAnterior);
+
+                                    // }
+                                }
+                                //////////////////////
+
+                            } // fin case 1
+                            break;
+
+                    }//fin swicth
+
+
+
+
+                    Label lblValoresReferencia = new Label();
+
+                    lblValoresReferencia.ID = "VR" + s_idDetalleProtocolo.ToString();
+                    lblValoresReferencia.Font.Name = "Arial";
+                    lblValoresReferencia.Font.Size = FontUnit.Point(8);
+                    lblValoresReferencia.Font.Italic = true;
+
+
+                    if (s_valorReferencia != "")
+                    {
+                        lblValoresReferencia.Text = s_valorReferencia;
+                        if (m_metodo != "")
+                            lblValoresReferencia.Text += " | " + m_metodo;
+                    }
+                    else
+                        lblValoresReferencia.Text = ""; // oDetalle.CalcularValoresReferencia();
+                                                        ///CARO: posibilidad de cambiar valor de refrencia - presentacion solo en validacion o control
+                    if ((Request["Operacion"].ToString() == "Valida") || (Request["Operacion"].ToString() == "Control"))
+                    {
+                        ///if (oDetalle.) si tiene mas de una presentacion
+                        lblValoresReferencia.Attributes.Add("onClick", "javascript:  AnalisisMetodoEdit (" + oDetalle.IdSubItem.IdItem.ToString() + "," + oDetalle.IdProtocolo.IdProtocolo.ToString() + ",790,420); return false");
+                        lblValoresReferencia.ForeColor = Color.Blue;
+                    }
+
+
+                    objCellReferencia.Controls.Add(lblValoresReferencia);
+
+
+                    Label lblPersona = new Label();
+                    lblPersona.Text = s_usuario;
+                    lblPersona.Font.Size = FontUnit.Point(7);
+                    lblPersona.Font.Italic = true;
+
+                    if (s_Validado == "2")
+                    {
+                        lblPersona.ForeColor = Color.Blue; //VALIDADO
+                        if (lblPersona.Text.Substring(0, 3).ToUpper() == "PRE")
+                            lblPersona.ForeColor = Color.Red;
+                    }
+                    if (s_Validado == "1") lblPersona.ForeColor = Color.Green; ///CONTROLADO
+                    if (lblPersona.Text.Length >= 10)
+                    {
+                        if (lblPersona.Text.Substring(0, 10).ToUpper() == "AUTOMÁTICO")
+                            lblPersona.ForeColor = Color.Red;
+                    }
+
+                    if (Request["Operacion"].ToString() == "Valida")
+                    {
+                        CheckBox chk1 = new CheckBox();
+                        chk1.ID = "chk" + s_idDetalleProtocolo;
+                        if ((estado == 2) && (Request["Operacion"].ToString() == "Carga")) //si esta validado y entro a controlar no puedo modificar
+                        {
+                            chk1.Visible = false;
+
+                        }
+                        objCellValida.Controls.Add(chk1);
+                    }
+
+
+
+                    objCellPersona.Controls.Add(lblPersona);
+
+
+                    ///Definir los anchos de las columnas
+                    objCellProtocolo.Width = Unit.Percentage(10);
+                    objCellFecha.Width = Unit.Percentage(5);
+                    objCellPaciente.Width = Unit.Percentage(35);
+                    objCellResultado.Width = Unit.Percentage(20);
+
+                    objCellReferencia.Width = Unit.Percentage(20);
+                    objCellPersona.Width = Unit.Percentage(10);
+
+
+
+                    ///////////////////////
+                    ///agrega a la fila cada una de las celdas
+
+                    objFila.Cells.Add(objCellProtocolo);
+                    objFila.Cells.Add(objCellFecha);
+                    objFila.Cells.Add(objCellPaciente);
+                    objFila.Cells.Add(objCellResultado);
+
+                    if (Request["Operacion"].ToString() == "Valida") objFila.Cells.Add(objCellResultadoAnterior);
+                    objFila.Cells.Add(objCellReferencia);
+                    //objFila.Cells.Add(objCellValoresReferencia);
+                    objFila.Cells.Add(objCellPersona); if (Request["Operacion"].ToString() == "Valida") objFila.Cells.Add(objCellValida);
+                    //objFila.Cells.Add(objCellValida);
+
+                    objFila.Cells.Add(objCellObservaciones);
+
+                    //////
+
+                    Master.FindControl("ContentPlaceHolder1").FindControl("Panel1").Controls.Add(tContenido);
+
+                    //'añadimos la fila a la tabla
+                    if (objFila != null)
+                        tContenido.Controls.Add(objFila);//.Rows.Add(objRow);                                
+                }
+            }
+
+
+        }
+        private void LlenarTabla_old(string p)
         {
             Item oItem = new Item();
             oItem = (Item)oItem.Get(typeof(Item), int.Parse(p));
@@ -804,8 +1578,8 @@ namespace WebLab.Resultados
 
                 tContenido.Controls.Add(objFila_TITULO);//.Rows.Add(objRow);    
 
-                
-                
+               
+
                 for (int i = 0; i < dt.Rows.Count; i++)
                 {
                 

--- a/WebLab/Turnos/Default.aspx
+++ b/WebLab/Turnos/Default.aspx
@@ -68,156 +68,9 @@
 <table style="width:100%" >
 				
 					 
-				<%--	<tr>
-							<td   >
-                                            DNI/LE/LC:</td>
-						<td align="left" colspan="2">
-                           <input id="txtDni" type="text" runat="server" style="width:100px;"  class="form-control input-sm"  
-                                onblur="valNumero(this)" maxlength="8" tabindex="0" />
-                            <asp:CompareValidator ID="cvDni" runat="server" ControlToValidate="txtDni" 
-                                ErrorMessage="Debe ingresar solo numeros" Operator="DataTypeCheck" 
-                                Type="Integer" ValidationGroup="0"></asp:CompareValidator>
-                        </td>
-						
-					</tr>
-					<tr>
-							<td   >
-                                            Apellido/s:</td>
-						<td align="left" colspan="2">
-                                            <asp:TextBox ID="txtApellido" runat="server" class="form-control input-sm" TabIndex="1" 
-                                                ValidationGroup="1" Width="150px"></asp:TextBox>
-                        </td>
-						
-					</tr>
-					<tr>
-							<td   >
-                                            Nombres/s:</td>
-						<td align="left" colspan="2">
-                                            <asp:TextBox ID="txtNombre" runat="server" class="form-control input-sm"  TabIndex="2" 
-                                                Width="216px"></asp:TextBox>
-                        </td>
-						
-					</tr>
-
-                    
-					<tr>
-						<td   >
-                                            Fecha de Nac.:</td>
-						<td align="left" colspan="2">
-                                            <input id="txtFechaNac" runat="server" type="text" maxlength="10" 
-                         onblur="valFecha(this)" 
-                        onkeyup="mascara(this,'/',patron,true)" tabindex="3" class="form-control input-sm" 
-                                style="width: 70px"  /></td>
-						
-					</tr>
-				
-					
-					<tr>
-						<td   >
-                                            Sexo:</td>
-						<td align="left" colspan="2">
-                                            <asp:DropDownList ID="ddlSexo" runat="server" TabIndex="4" class="form-control input-sm" >
-                                                <asp:ListItem Value="0" Selected="True">Todos</asp:ListItem>
-                                                <asp:ListItem Value="2">Femenino</asp:ListItem>
-                                                <asp:ListItem Value="3">Masculino</asp:ListItem>
-                                                <asp:ListItem Value="1">Indeterminado</asp:ListItem>
-                                            </asp:DropDownList>
-                        </td>
-						
-					</tr>
-					<tr>
-						<td   colspan="3">
-                                            <hr /></td>
-						
-					</tr>
-					<tr>
-						<td  >
-                                  <asp:LinkButton ID="btnBuscar" runat="server" CssClass="btn btn-info" OnClick="btnBuscar_Click"    Width="100px" >
-                                             <span class="glyphicon glyphicon-search"></span>&nbsp;Buscar</asp:LinkButton>       
-                                        <%--    <asp:Button ID="btnBuscar" runat="server" Text="Buscar" ValidationGroup="0" 
-                                               CssClass="myButton" TabIndex="5" onclick="btnBuscar_Click" />--%>
-                      <%--   </td>
-						<td align="left">
-                                            <asp:CustomValidator ID="cvDatosEntrada" runat="server" 
-                                                ErrorMessage="Debe ingresar al menos un parametro de busqueda" 
-                                                onservervalidate="cvDatosEntrada_ServerValidate" ValidationGroup="0"></asp:CustomValidator>
-                        </td>
-						
-						<td align="right">
-                                      
-                              <asp:HyperLink ID="HyperLink1"  runat="server"  CssClass="btn btn-danger" Width="150px" 
-                                               ToolTip="Crear un nuevo paciente en el SIPS" Target="_self">Nuevo Paciente</asp:HyperLink> 
-                                               
-                                                 <asp:Button ToolTip="Crear un nuevo paciente "  CssClass="btn btn-primary"
-                                               ID="btnSeleccionarPaciente" Width="150px" runat="server" Text="Nuevo Paciente" 
-                                               OnClientClick="seleccionarPaciente(); return false;" visible="false"
-                                               onclick="btnSeleccionarPaciente_Click" TabIndex="100" 
-                                               UseSubmitBehavior="False" />
-        <br />
-        <asp:HiddenField ID="hfPaciente" runat="server" />
-                                               </td>
-						
-					</tr>
-					<tr>
-						<td   colspan="3">
-                                            &nbsp;</td>
-						
-					</tr>
-					<tr>
-						<td   colspan="3" style="vertical-align: top">
-        <asp:GridView ID="gvLista" runat="server" AutoGenerateColumns="False" DataKeyNames="idPaciente" CssClass="table table-bordered bs-table"  PageSize="15" 
-                                
-                                
-                                EmptyDataText="No se encontraron pacientes para los parametros de busqueda ingresados" 
-                                onrowcommand="gvLista_RowCommand" onrowdatabound="gvLista_RowDataBound" 
-                                TabIndex="5" 
-                                GridLines="None" onpageindexchanging="gvLista_PageIndexChanging" 
-                               Width="600px">
-           
-
-            <Columns>
-                <asp:TemplateField>
-                            <ItemTemplate>
-                            <asp:ImageButton ID="Editar" runat="server" ImageUrl="~/App_Themes/default/images/editar.jpg" 
-                            ommandName="Editar" />
-                            </ItemTemplate>
-                          
-                               <ItemStyle Width="18px" HorizontalAlign="Center" Height="18px" />
-                          
-                        </asp:TemplateField>
-                <asp:BoundField DataField="dni" HeaderText="DNI" >
-                    <ItemStyle Width="15%" HorizontalAlign="Center" />
-                </asp:BoundField>
-                <asp:BoundField DataField="paciente" HeaderText="Apellidos y Nombres">
-                    <ItemStyle Width="65%" />
-                </asp:BoundField>
-                 <asp:BoundField DataField="sexo" HeaderText="Sexo">
-                     <ItemStyle HorizontalAlign="Center" />
-                </asp:BoundField>
-                 <asp:BoundField DataField="fechaNacimiento" HeaderText="Fecha Nacimiento">
-                     <ItemStyle HorizontalAlign="Center" Width="15%" />
-                </asp:BoundField>
-                 <asp:TemplateField>
-                            <ItemTemplate>
-                            <asp:ImageButton ID="Turno" runat="server" ImageUrl="~/App_Themes/default/images/flecha.jpg" 
-                            ommandName="Turno" />
-                            </ItemTemplate>
-                          
-                               <ItemStyle Width="18px" HorizontalAlign="Center" Height="18px" />
-                          
-                        </asp:TemplateField>
-            </Columns>
-            <FooterStyle BackColor="#5D7B9D" Font-Bold="True" ForeColor="White" />
-            <PagerStyle BackColor="#284775" ForeColor="White" HorizontalAlign="Center" />
-            <SelectedRowStyle BackColor="#E2DED6" Font-Bold="True" ForeColor="#333333" />
-            <HeaderStyle BackColor="#3A93D2" Font-Bold="True" ForeColor="White" 
-                Font-Names="Arial" Font-Size="8pt" />
-            <EditRowStyle BackColor="#999999" />
-            <AlternatingRowStyle BackColor="White" ForeColor="#284775" />
-        </asp:GridView>
-                        </td>
-						
-					</tr>--%>
+				<%--<asp:RangeValidator ID="rvSexo" runat="server" 
+                                ControlToValidate="ddlSexo" ErrorMessage="Sexo" MaximumValue="999999" 
+                                MinimumValue="1" Type="Integer" ValidationGroup="0">*</asp:RangeValidator>--%>                      <%--		<td rowspan="4" >   </td>--%>
 
 
 
@@ -254,9 +107,8 @@
 					
 					<tr>
 						<td   style="width: 150px">
-                                            Sexo:<asp:RangeValidator ID="rvSexo" runat="server" 
-                                ControlToValidate="ddlSexo" ErrorMessage="Sexo" MaximumValue="999999" 
-                                MinimumValue="1" Type="Integer" ValidationGroup="0">*</asp:RangeValidator>
+                                            Sexo:
+                                            <%--	<td rowspan="3" >   </td>--%>
                                         </td>
 						<td align="left" colspan="2">
                                             <asp:DropDownList ID="ddlSexo" runat="server" TabIndex="2" class="form-control input-sm">
@@ -265,8 +117,12 @@
                                                 <asp:ListItem Value="3">Masculino</asp:ListItem>
                                              
                                             </asp:DropDownList>
+                                            <asp:Label ID="lblMensajeSexo" runat="server" Font-Bold="True" ForeColor="#CC3300" Visible="False"></asp:Label>
                         </td>
-				<%--		<td rowspan="4" >   </td>--%>
+                        <%--	<td align="right" >
+        <br />
+        
+        </td>--%>
 					</tr>
 				
 					

--- a/WebLab/Turnos/Default.aspx.cs
+++ b/WebLab/Turnos/Default.aspx.cs
@@ -81,11 +81,12 @@ namespace WebLab.Turnos
         }
         private void CargarGrilla()
         {
-            string m_sexo = "F";
-            if (ddlSexo.SelectedValue == "2")
-                m_sexo = "F";
-            else
-                m_sexo = "M";
+            string m_sexo = ""; lblMensajeSexo.Visible = false;
+            //string m_sexo = "F";
+            //if (ddlSexo.SelectedValue == "2")
+            //    m_sexo = "F";
+            //else
+            //    m_sexo = "M";
 
 
 
@@ -98,11 +99,21 @@ namespace WebLab.Turnos
 
                 if (gvLista.Rows.Count == 0)
                 {
-                    lblMensaje.Visible = false;
-
-
-                    Response.Redirect("../Protocolos/ProcesaRenaper.aspx?Tipo=" + ddlTipo.SelectedValue + "&dni=" + txtDni.Value + "&sexo=" + m_sexo + "&llamada=LaboTurno&idServicio=" + Session["idServicio"].ToString() + "&idUrgencia=0"); // + Session["idUrgencia"].ToString());
-
+                    if (ddlSexo.SelectedValue != "0")  // se debe seleccionar el sexo para generar un paciente nuevo
+                    {
+                          m_sexo = "F";
+                        if (ddlSexo.SelectedValue == "2")
+                            m_sexo = "F";
+                        else
+                            m_sexo = "M";
+                        lblMensaje.Visible = false;
+                        Response.Redirect("../Protocolos/ProcesaRenaper.aspx?Tipo=" + ddlTipo.SelectedValue + "&dni=" + txtDni.Value + "&sexo=" + m_sexo + "&llamada=LaboTurno&idServicio=" + Session["idServicio"].ToString() + "&idUrgencia=0"); // + Session["idUrgencia"].ToString());
+                    }
+                    else
+                    {
+                        lblMensajeSexo.Text = "Debe ingresar un sexo para generar un paciente nuevo";
+                        lblMensajeSexo.Visible = true;
+                    }
 
                 }
                 else
@@ -112,28 +123,60 @@ namespace WebLab.Turnos
 
             if ((ddlTipo.SelectedValue == "T"))
             { //temporal
+
+
                 if ((txtDni.Value != "") || (txtNumeroAdicional.Text != ""))
                 {
+
                     gvLista.DataSource = LeerDatos();
                     gvLista.DataBind();
 
 
                     if (gvLista.Rows.Count == 0)
                     {
-                        lblMensaje.Visible = false;
+                        if (ddlSexo.SelectedValue != "0")
+                        {
+                            m_sexo = "F";
+                            if (ddlSexo.SelectedValue == "2")
+                                m_sexo = "F";
+                            else
+                                m_sexo = "M";
+                            lblMensaje.Visible = false;
 
 
-                        Response.Redirect("../Protocolos/ProcesaRenaperT.aspx?Tipo=" + ddlTipo.SelectedValue + "&dni=" + txtDni.Value + "&sexo=" + m_sexo + "&llamada=LaboTurno&idServicio=" + Session["idServicio"].ToString() + "&idUrgencia=0" );// + Session["idUrgencia"].ToString());
+                            Response.Redirect("../Protocolos/ProcesaRenaperT.aspx?Tipo=" + ddlTipo.SelectedValue + "&dni=" + txtDni.Value + "&sexo=" + m_sexo + "&llamada=LaboTurno&idServicio=" + Session["idServicio"].ToString() + "&idUrgencia=0");// + Session["idUrgencia"].ToString());
+                        }
+                        else
+                        {
 
-
+                            lblMensajeSexo.Text = "Debe ingresar un sexo para generar un paciente nuevo";
+                            lblMensajeSexo.Visible = true;
+                        }
                     }
                     else
                         lblMensaje.Visible = true;
                 }
 
                 else
+                {
+                    if (ddlSexo.SelectedValue != "0")
+                    {
+                        m_sexo = "F";
+                        if (ddlSexo.SelectedValue == "2")
+                            m_sexo = "F";
+                        else
+                            m_sexo = "M";
+                        lblMensaje.Visible = false;
+                        Response.Redirect("../Protocolos/ProcesaRenaperT.aspx?Tipo=" + ddlTipo.SelectedValue + "&dni=" + txtDni.Value + "&sexo=" + m_sexo + "&llamada=LaboTurno&idServicio=" + Session["idServicio"].ToString() + "&idUrgencia=0"); // + Session["idUrgencia"].ToString());
+                    }
+                    else
+                    {
 
-                    Response.Redirect("../Protocolos/ProcesaRenaperT.aspx?Tipo=" + ddlTipo.SelectedValue + "&dni=" + txtDni.Value + "&sexo=" + m_sexo + "&llamada=LaboTurno&idServicio=" + Session["idServicio"].ToString() + "&idUrgencia=0"); // + Session["idUrgencia"].ToString());
+                        lblMensajeSexo.Text = "Debe ingresar un sexo para generar un paciente nuevo";
+                        lblMensajeSexo.Visible = true;
+                    }
+                }
+               
             }
 
 

--- a/WebLab/Turnos/Default.aspx.designer.cs
+++ b/WebLab/Turnos/Default.aspx.designer.cs
@@ -40,15 +40,6 @@ namespace WebLab.Turnos {
         protected global::System.Web.UI.WebControls.CompareValidator cvDni;
         
         /// <summary>
-        /// rvSexo control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.WebControls.RangeValidator rvSexo;
-        
-        /// <summary>
         /// ddlSexo control.
         /// </summary>
         /// <remarks>
@@ -56,6 +47,15 @@ namespace WebLab.Turnos {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.DropDownList ddlSexo;
+        
+        /// <summary>
+        /// lblMensajeSexo control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Label lblMensajeSexo;
         
         /// <summary>
         /// txtNumeroAdicional control.

--- a/WebLab/Turnos/TurnosEdit2.aspx.cs
+++ b/WebLab/Turnos/TurnosEdit2.aspx.cs
@@ -60,8 +60,8 @@ namespace WebLab.Turnos
                 oUser = (Usuario)oUser.Get(typeof(Usuario), int.Parse(Session["idUsuario"].ToString()));
                 if (oUser.IdPerfil.IdPerfil!=15)  ///no sea un externo; si es externo no hay registro en la lab_confi
                     oC = (Configuracion)oC.Get(typeof(Configuracion), "IdEfector", oUser.IdEfector);
-         
-            }
+           
+        }
             else Response.Redirect("../FinSesion.aspx", false);
 
 
@@ -255,6 +255,73 @@ namespace WebLab.Turnos
 
 
         }
+        private void BuscarCodigoDiagnostico()
+        {
+            lstDiagnosticos.Items.Clear();
+            if (txtCodigoDiagnostico.Text != "")
+            {
+
+
+
+                if (oC.NomencladorDiagnostico == 0) /// Cie10
+                {
+                    string m_strSQL = @"select id, codigo + ' -' + nombre from sys_cie10 with (nolock) where tipo='DIAG' and CODIGO like '%" + txtCodigoDiagnostico.Text.Trim() + "%'";
+
+                    DataSet Ds = new DataSet();
+                    SqlConnection conn = new SqlConnection(ConfigurationManager.ConnectionStrings["SIL_ReadOnly"].ConnectionString); ///Performance: conexion de solo lectura
+                    SqlDataAdapter adapter = new SqlDataAdapter();
+                    adapter.SelectCommand = new SqlCommand(m_strSQL, conn);
+                    adapter.Fill(Ds);
+                    lstDiagnosticos.Items.Clear();
+                    int cantDiag = Ds.Tables[0].Rows.Count;
+                    for (int i = 0; i < cantDiag; i++)
+                    {
+
+                        ListItem oDia = new ListItem();
+                        oDia.Text = Ds.Tables[0].Rows[i][1].ToString();
+                        oDia.Value = Ds.Tables[0].Rows[i][0].ToString();
+                        lstDiagnosticos.Items.Add(oDia);
+
+                        if (cantDiag == 1) //Si encuentra por codigo un unico diagnsotico se pasa automatico a diagnostico del paciente para evitar mas clic: sug. H. Plottier
+                        {
+                            if (!ExisteItem(lstDiagnosticosFinal, oDia.Value))
+                            {
+                                //    lstDiagnosticosFinal.Items.Clear();
+                                lstDiagnosticosFinal.Items.Add(oDia);
+                                lstDiagnosticosFinal.UpdateAfterCallBack = true;
+
+                            }
+                        }
+                    }
+
+
+
+
+                }
+                else /// diagnostico propio
+                {
+                    DiagnosticoP oDiagnostico = new DiagnosticoP();
+                    oDiagnostico = (DiagnosticoP)oDiagnostico.Get(typeof(DiagnosticoP), "Codigo", txtCodigoDiagnostico.Text);
+                    if (oDiagnostico != null)
+                    {
+                        ListItem oDia = new ListItem();
+                        oDia.Text = oDiagnostico.Codigo + " - " + oDiagnostico.Nombre;
+                        oDia.Value = oDiagnostico.IdDiagnostico.ToString();
+                        lstDiagnosticos.Items.Add(oDia);
+
+                    }
+                    else
+                        lstDiagnosticos.Items.Clear();
+                }
+
+            }
+            lstDiagnosticos.UpdateAfterCallBack = true;
+
+        }
+        private bool ExisteItem(ListControl lista, string value)
+        {
+            return lista.Items.FindByValue(value) != null;
+        }
 
         private void BuscarDiagnostico()
         {
@@ -262,45 +329,130 @@ namespace WebLab.Turnos
             lstDiagnosticos.Items.Clear();
             if (txtCodigoDiagnostico.Text != "")
             {
-                Cie10 oDiagnostico = new Cie10();
-                oDiagnostico = (Cie10)oDiagnostico.Get(typeof(Cie10), "Codigo", txtCodigoDiagnostico.Text);
-                if (oDiagnostico != null)
-                {
-                    ListItem oDia = new ListItem();
-                    oDia.Text = oDiagnostico.Codigo + " - " + oDiagnostico.Nombre;
-                    oDia.Value = oDiagnostico.Id.ToString();
-                    lstDiagnosticos.Items.Add(oDia);
-                    //Si encuentra por codigo un unico diagnsotico se pasa automatico a diagnostico del paciente para evitar mas clic: sug. H. Plottier
-                    lstDiagnosticosFinal.Items.Clear();
-                    lstDiagnosticosFinal.Items.Add(oDia);
-                    lstDiagnosticosFinal.UpdateAfterCallBack = true;
+                BuscarCodigoDiagnostico();
+                //Cie10 oDiagnostico = new Cie10();
+                //oDiagnostico = (Cie10)oDiagnostico.Get(typeof(Cie10), "Codigo", txtCodigoDiagnostico.Text);
+                //if (oDiagnostico != null)
+                //{
+                //    ListItem oDia = new ListItem();
+                //    oDia.Text = oDiagnostico.Codigo + " - " + oDiagnostico.Nombre;
+                //    oDia.Value = oDiagnostico.Id.ToString();
+                //    lstDiagnosticos.Items.Add(oDia);
+                //    //Si encuentra por codigo un unico diagnsotico se pasa automatico a diagnostico del paciente para evitar mas clic: sug. H. Plottier
+                //    //   lstDiagnosticosFinal.Items.Clear();
 
-                }
-                else
-                    lstDiagnosticos.Items.Clear();
+
+                //    // Verificar si ya existe en lstDiagnosticosFinal
+                //    bool existeEnFinal = lstDiagnosticosFinal.Items.Cast<ListItem>()
+                //                              .Any(item => item.Value == oDia.Value);
+
+                //    if (!existeEnFinal)
+                //    {
+                //        lstDiagnosticosFinal.Items.Add(oDia);
+                //        lstDiagnosticosFinal.UpdateAfterCallBack = true;
+                //    }
+                //    //lstDiagnosticosFinal.Items.Add(oDia);
+                //    //lstDiagnosticosFinal.UpdateAfterCallBack = true;
+
+                //}
+                //else
+                //{
+                //    lstDiagnosticos.Items.Clear();
+                //    lstDiagnosticos.UpdateAfterCallBack = true;
+                //}
             }
 
             if (txtNombreDiagnostico.Text != "")
             {
-                lstDiagnosticos.Items.Clear();
-                ISession m_session = NHibernateHttpModule.CurrentSession;
-                ICriteria crit = m_session.CreateCriteria(typeof(Cie10));
-                crit.Add(Expression.Sql(" Nombre like '%" + txtNombreDiagnostico.Text + "%' order by Nombre"));
+                BuscarNombreDiagnostico();
+                //lstDiagnosticos.Items.Clear();
+                //ISession m_session = NHibernateHttpModule.CurrentSession;
+                //ICriteria crit = m_session.CreateCriteria(typeof(Cie10));
+                //crit.Add(Expression.Sql(" Nombre like '%" + txtNombreDiagnostico.Text + "%' order by Nombre"));
 
-                IList items = crit.List();
+                //IList items = crit.List();
 
-                foreach (Cie10 oDiagnostico in items)
-                {
-                    ListItem oDia = new ListItem();
-                    oDia.Text = oDiagnostico.Codigo + " - " + oDiagnostico.Nombre;
-                    oDia.Value = oDiagnostico.Id.ToString();
-                    lstDiagnosticos.Items.Add(oDia);
-                }
+                //foreach (Cie10 oDiagnostico in items)
+                //{
+                //    ListItem oDia = new ListItem();
+                //    oDia.Text = oDiagnostico.Codigo + " - " + oDiagnostico.Nombre;
+                //    oDia.Value = oDiagnostico.Id.ToString();
+                //    lstDiagnosticos.Items.Add(oDia);
+                //    lstDiagnosticos.UpdateAfterCallBack = true;
+                //}
 
 
             }
-            lstDiagnosticos.UpdateAfterCallBack = true;
+         
 
+        }
+
+        private void BuscarNombreDiagnostico()
+        {
+            lstDiagnosticos.Items.Clear();
+            if (txtNombreDiagnostico.Text != "")
+            {
+
+                ISession m_session = NHibernateHttpModule.CurrentSession;
+                if (oC.NomencladorDiagnostico == 0)
+                {
+                    //ICriteria crit = m_session.CreateCriteria(typeof(Cie10));
+                    //crit.Add(Expression.Sql(" Nombre like '%" + txtNombreDiagnostico.Text + "%' order by Nombre"));
+
+                    //IList items = crit.List();
+
+                    //foreach (Cie10 oDiagnostico in items)
+                    //{
+                    //    ListItem oDia = new ListItem();
+                    //    oDia.Text = oDiagnostico.Codigo + " - " + oDiagnostico.Nombre;
+                    //    oDia.Value = oDiagnostico.Id.ToString();
+                    //    lstDiagnosticos.Items.Add(oDia);
+                    //}
+
+
+                    string m_strSQL = @"select id, codigo + ' -' + nombre from sys_cie10 (nolock) where  tipo='DIAG' and  Nombre like '%" + txtNombreDiagnostico.Text.Trim() + "%' order by Nombre";
+
+                    DataSet Ds = new DataSet();
+                    SqlConnection conn = new SqlConnection(ConfigurationManager.ConnectionStrings["SIL_ReadOnly"].ConnectionString); ///Performance: conexion de solo lectura
+                    SqlDataAdapter adapter = new SqlDataAdapter();
+                    adapter.SelectCommand = new SqlCommand(m_strSQL, conn);
+                    adapter.Fill(Ds);
+                    lstDiagnosticos.Items.Clear();
+                    for (int i = 0; i < Ds.Tables[0].Rows.Count; i++)
+                    {
+
+                        ListItem oDia = new ListItem();
+                        oDia.Text = Ds.Tables[0].Rows[i][1].ToString();
+                        oDia.Value = Ds.Tables[0].Rows[i][0].ToString();
+                        lstDiagnosticos.Items.Add(oDia);
+
+
+                    }
+
+
+                    lstDiagnosticos.UpdateAfterCallBack = true;
+                }
+
+                else //nomenclador propio
+                {
+                    ICriteria crit1 = m_session.CreateCriteria(typeof(DiagnosticoP));
+
+                    crit1.Add(Expression.InsensitiveLike("Nombre", txtNombreDiagnostico.Text, MatchMode.Anywhere));
+                    crit1.Add(Expression.Eq("Baja", false));
+                    IList items = crit1.List();
+
+                    foreach (DiagnosticoP oDiagnostico in items)
+                    {
+                        ListItem oDia = new ListItem();
+                        oDia.Text = oDiagnostico.Codigo + " - " + oDiagnostico.Nombre;
+                        oDia.Value = oDiagnostico.IdDiagnostico.ToString();
+                        lstDiagnosticos.Items.Add(oDia);
+                    }
+
+                    lstDiagnosticos.UpdateAfterCallBack = true;
+                }
+
+            }
         }
 
         protected void btnBusquedaFrecuente_Click(object sender, EventArgs e)
@@ -321,7 +473,7 @@ namespace WebLab.Turnos
             string m_ssql = @"SELECT top 20 ID, Codigo + ' - ' + Nombre as nombre, count (*)  cantidad
 FROM Sys_CIE10 c with (nolock) 
 inner join LAB_ProtocoloDiagnostico p with (nolock)  on c.id = p.idDiagnostico
-where p.idEfector=" + oUser.IdEfector.IdEfector.ToString()+ @"
+where  c.tipo='DIAG' and  p.idEfector=" + oUser.IdEfector.IdEfector.ToString()+ @"
 group by id, codigo, nombre
 ORDER BY cantidad desc";
             oUtil.CargarListBox(lstDiagnosticos, m_ssql, "id", "nombre");


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
<!-- URL de la User Story, referencia al issue (#1111) o breve descripcion del requerimiento -->
https://proyectos.andes.gob.ar/browse/LAB-236

Para simular el bug que han reportado los usuarios:
En el alta de un protocolo, después de ingresar determinaciones desde la lista de perfiles (por ejemplo, “Carga Viral” como se ve en el combo de la pantalla), al ingresar códigos manualmente (por ej., 412) y luego borrar determinaciones, sin cargar diagnóstico, sin ingresar médico y sin seleccionar servicio, al hacer “Guardar” se marcan todas como “sin muestra” de forma automática.

### Funcionalidad desarrollada 
<!-- Describir que se desarrollo -->
1. Se corrigio OrdenarDatos() que en vez de cargar el check del checkbox cargaba el value, dejandolo siempre en "on".
### UserStories llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
<!-- Indique el cambio en caso afirmativo, agradecemos si es en forma de comando en mongo además de una explicación -->
- [ ] Si
- [ ] No
- [x] No corresponde


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
